### PR TITLE
Allow users to specify themselves in the timezone user option

### DIFF
--- a/src/discord/commands/timezone.ts
+++ b/src/discord/commands/timezone.ts
@@ -93,7 +93,7 @@ export default {
     let discordId = interaction.user.id;
     let whose = "Your";
 
-    if (targetUser) {
+    if (targetUser && targetUser.id !== interaction.user.id) {
       if (!inGuild(interaction, opId) || !requireRole(interaction, opId, Role.PREFECT | Role.PROFESSOR | Role.OWNER))
         return;
       discordId = targetUser.id;


### PR DESCRIPTION
Users who pass their own name in the user field no longer need
Prefect/Professor/Owner role - the role check is skipped when
targetUser matches the invoking user.