### PR TITLE
Fix TypeError when /admin is used in a DM

### DIFF
--- a/src/discord/events/interactionCreate/admin/index.ts
+++ b/src/discord/events/interactionCreate/admin/index.ts
@@ -41,6 +41,7 @@ export default {
   data: new SlashCommandBuilder()
     .setName("admin")
     .setDescription("Admin commands")
+    .setDMPermission(false)
     .addSubcommand((subcommand) =>
       subcommand
         .setName("adjust-points")

--- a/src/discord/utils/interaction.ts
+++ b/src/discord/utils/interaction.ts
@@ -26,7 +26,7 @@ export function inGuild(
   interaction: ChatInputCommandInteraction,
 ): interaction is ChatInputCommandInteraction<"cached"> {
   if (!interaction.inCachedGuild()) {
-    void errorReply(interaction, "Invalid Context", "This command can only be used in a server.");
+    void errorReply(interaction, "Invalid Context", "This command can only be used in a server.").catch(() => undefined);
     return false;
   }
   return true;

--- a/src/discord/utils/role.ts
+++ b/src/discord/utils/role.ts
@@ -10,7 +10,7 @@ export function requireRole(interaction: ChatInputCommandInteraction<"cached">, 
     if (roles & Role.OWNER) roleNames.push("OWNER");
     if (roles & Role.PREFECT) roleNames.push("PREFECT");
     if (roles & Role.PROFESSOR) roleNames.push("PROFESSOR");
-    void errorReply(interaction, "Insufficient Permissions", `Only ${roleNames.join(" or ")} can use this command.`);
+    void errorReply(interaction, "Insufficient Permissions", `Only ${roleNames.join(" or ")} can use this command.`).catch(() => undefined);
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary

- Add `.setDMPermission(false)` to `/admin` command so Discord blocks DM usage before the bot even sees the interaction
- Add `.catch(() => undefined)` to fire-and-forget `errorReply()` calls in `inGuild()` and `requireRole()` to prevent unhandled rejections if Discord rejects the reply (e.g. expired interaction)

## Root cause

A user invoked `/admin` in a DM. Since `setDMPermission` was not set, Discord allowed it. The bot's `inGuild()` guard fired and called `void errorReply(...)` — but without `.catch()`. If that reply itself failed, the rejection was unhandled and propagated as:

```
Unhandled Rejection, reason: TypeError: Cannot read properties of undefined (reading 'has')
```

The `cmd` opId prefix confirmed it originated in the `InteractionCreate` handler.

## Test plan

- [ ] Verify `/admin` is no longer available in DMs (Discord should grey it out)
- [ ] Confirm no unhandled rejection alerts when a non-guild interaction is received