### PR TITLE
fix(house): handle members with multiple house roles gracefully

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -322,7 +322,7 @@ export function getHouseFromMember(member: GuildMember | null): House | null {
 
   const houses = HOUSE_ROLES.filter(([roleId]) => roles.has(roleId));
   if (houses.length > 1) {
-    // Temporary states (e.g. mid-resort) can leave a user with multiple house roles.
+    // Temporary states can leave a user with multiple house roles.
     // Treat the house as unknown rather than crashing the interaction.
     houseLog.warn("Member has multiple house roles", {
       userId: member.id,

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -21,7 +21,6 @@ import { sql } from "drizzle-orm/sql/sql";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 import dayjs from "dayjs";
 import { MIN_MONTHLY_POINTS_FOR_WEIGHTED, SETTINGS_KEYS } from "../common/constants.ts";
-import assert from "node:assert/strict";
 import type { CountingState, House, HousePoints } from "@/common/types.ts";
 import { createLogger } from "@/common/logging/logger.ts";
 
@@ -315,14 +314,22 @@ export async function getUnweightedHousePoints(db: DbOrTx): Promise<HousePoints[
     .then((rows) => rows.filter((r): r is HousePoints => r.house !== null));
 }
 
-export function getHouseFromMember(member: GuildMember | null): House | undefined {
-  if (!member?.roles.cache) return undefined;
+const houseLog = createLogger("House");
+
+export function getHouseFromMember(member: GuildMember | null): House | null {
+  if (!member?.roles.cache) return null;
   const roles = member.roles.cache;
 
   const houses = HOUSE_ROLES.filter(([roleId]) => roles.has(roleId));
-  assert(
-    houses.length <= 1,
-    `Member ${member.user.tag} has multiple house roles: ${houses.map(([, name]) => name).join(", ")}`,
-  );
-  return houses[0]?.[1];
+  if (houses.length > 1) {
+    // Temporary states (e.g. mid-resort) can leave a user with multiple house roles.
+    // Treat the house as unknown rather than crashing the interaction.
+    houseLog.warn("Member has multiple house roles", {
+      userId: member.id,
+      user: member.user.tag,
+      houses: houses.map(([, name]) => name).join(","),
+    });
+    return null;
+  }
+  return houses[0]?.[1] ?? null;
 }

--- a/src/discord/events/interactionCreate/submit/index.ts
+++ b/src/discord/events/interactionCreate/submit/index.ts
@@ -71,7 +71,15 @@ export default {
     const submissionType = interaction.options.getString("type", true) as SubmissionType;
 
     const house = getHouseFromMember(interaction.member);
-    assert(house, "User does not have a house role assigned");
+    if (!house) {
+      await errorReply(
+        interaction,
+        "No House Assigned",
+        "You do not have exactly one house role assigned. Please contact a Prefect to fix your house roles before submitting.",
+        { deferred: true },
+      );
+      return;
+    }
 
     // Fetch user's timezone for validation and display
     const userTimezone = await getUserTimezone(interaction.member.id);


### PR DESCRIPTION
A user briefly holding more than one house role (e.g. mid-resort) used
to crash any interaction via an AssertionError in getHouseFromMember,
which broke commands like /timezone for the affected user. Return null
in that case, log a warning, and persist house=null in userTable so the
ensureUserExists upsert no longer crashes. /submit now replies with a
friendly error instead of asserting when the user has no resolvable
house.

https://claude.ai/code/session_01BoKPwFatyVU8v6qT6B2Nw6