### PR TITLE
Use a single neutral colour for all veils in mystery mode

### DIFF
--- a/src/web/routes/index.ts
+++ b/src/web/routes/index.ts
@@ -74,18 +74,13 @@ export default function registerIndexRoute(app: Router) {
     const mysteryMode = await isMysteryMode(req.query);
 
     // In mystery mode, strip every standings-revealing field from the payload so the
-    // data is absent from the HTML source entirely, not merely hidden with CSS. Only
-    // the house colour is kept (it draws the hourglass but reveals no placing), and the
-    // order is shuffled so position can't hint at the ranking either.
+    // data is absent from the HTML source entirely, not merely hidden with CSS. The
+    // house colour is dropped too — it would still outline which veil is which house —
+    // so all veils are rendered identically in a single neutral mystery hue.
+    const MYSTERY_VEIL_COLOR = "#8a6dc2";
     let displayHouses: { color: string }[] | typeof houses = houses;
     if (mysteryMode) {
-      const pool = [...houses];
-      const shuffled: { color: string }[] = [];
-      while (pool.length > 0) {
-        const [picked] = pool.splice(Math.floor(Math.random() * pool.length), 1);
-        if (picked) shuffled.push({ color: picked.color });
-      }
-      displayHouses = shuffled;
+      displayHouses = houses.map(() => ({ color: MYSTERY_VEIL_COLOR }));
     }
 
     const chartData = mysteryMode ? null : buildHousePaceChart(dailyEvents, monthStart);


### PR DESCRIPTION
## Summary

Mystery mode previously still sent each house's colour, which outlined every veil in that house's colour and so identified which veil belonged to which house. This drops the colour and renders all veils in a single neutral mystery hue (`#8a6dc2`), so no house can be identified at all.

Because all veils are now identical and carry no data, the shuffle is no longer needed and has been removed.

## Changes

- `src/web/routes/index.ts`: in mystery mode, map every house to a single neutral colour instead of its house colour; remove the now-redundant shuffle.

## Result

In mystery mode the HTML source contains four identical, anonymous veils — no house colours, names, points, ranks, or member counts.

https://claude.ai/code/session_014PjSvDzZyHoAQ1RUuj7NLX

---
_Generated by [Claude Code](https://claude.ai/code/session_014PjSvDzZyHoAQ1RUuj7NLX)_