### PR TITLE
Reset stale stats on member rejoin instead of at next hourly tick

### DIFF
--- a/drizzle/0033_add_user_left_at.sql
+++ b/drizzle/0033_add_user_left_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "left_at" timestamp;

--- a/drizzle/meta/0033_snapshot.json
+++ b/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,863 @@
+{
+  "id": "a77c0a5b-82c0-417e-989e-1ca122e74b7f",
+  "prevId": "7025dfc7-60f3-45a0-aee3-707709099ff7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.house_cup_entry": {
+      "name": "house_cup_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "month_id": {
+          "name": "month_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house": {
+          "name": "house",
+          "type": "house",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weighted_points": {
+          "name": "weighted_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_points": {
+          "name": "raw_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualifying_count": {
+          "name": "qualifying_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "champion": {
+          "name": "champion",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "house_cup_entry_month_id_idx": {
+          "name": "house_cup_entry_month_id_idx",
+          "columns": [
+            {
+              "expression": "month_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "house_cup_entry_month_id_house_cup_month_id_fk": {
+          "name": "house_cup_entry_month_id_house_cup_month_id_fk",
+          "tableFrom": "house_cup_entry",
+          "tableTo": "house_cup_month",
+          "columnsFrom": [
+            "month_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "house_cup_entry_champion_user_discord_id_fk": {
+          "name": "house_cup_entry_champion_user_discord_id_fk",
+          "tableFrom": "house_cup_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "champion"
+          ],
+          "columnsTo": [
+            "discord_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house_cup_month": {
+      "name": "house_cup_month",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner": {
+          "name": "winner",
+          "type": "house",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "house_cup_month_month_unique": {
+          "name": "house_cup_month_month_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "month"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.house_scoreboard": {
+      "name": "house_scoreboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "house": {
+          "name": "house",
+          "type": "house",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entry": {
+      "name": "journal_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "journal_entry_date_idx": {
+          "name": "journal_entry_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.point_adjustment": {
+      "name": "point_adjustment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjusted_by": {
+          "name": "adjusted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "point_adjustment_discord_id_created_at_idx": {
+          "name": "point_adjustment_discord_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "discord_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "point_adjustment_discord_id_user_discord_id_fk": {
+          "name": "point_adjustment_discord_id_user_discord_id_fk",
+          "tableFrom": "point_adjustment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "discord_id"
+          ],
+          "columnsTo": [
+            "discord_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submission": {
+      "name": "submission",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "house": {
+          "name": "house",
+          "type": "house",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house_id": {
+          "name": "house_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screenshot_url": {
+          "name": "screenshot_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submission_type": {
+          "name": "submission_type",
+          "type": "submission_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "submission_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "linked_submission_id": {
+          "name": "linked_submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "submission_discordId_status_submitted_at_idx": {
+          "name": "submission_discordId_status_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "discord_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submission_house_submitted_at_idx": {
+          "name": "submission_house_submitted_at_idx",
+          "columns": [
+            {
+              "expression": "house",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "submitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submission_discord_id_user_discord_id_fk": {
+          "name": "submission_discord_id_user_discord_id_fk",
+          "tableFrom": "submission",
+          "tableTo": "user",
+          "columnsFrom": [
+            "discord_id"
+          ],
+          "columnsTo": [
+            "discord_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "submission_linked_submission_id_submission_id_fk": {
+          "name": "submission_linked_submission_id_submission_id_fk",
+          "tableFrom": "submission",
+          "tableTo": "submission",
+          "columnsFrom": [
+            "linked_submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submission_messageId_unique": {
+          "name": "submission_messageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "house": {
+          "name": "house",
+          "type": "house",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "last_daily_reset": {
+          "name": "last_daily_reset",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_points": {
+          "name": "daily_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_points": {
+          "name": "monthly_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_points": {
+          "name": "total_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "daily_voice_time": {
+          "name": "daily_voice_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthly_voice_time": {
+          "name": "monthly_voice_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_voice_time": {
+          "name": "total_voice_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "daily_messages": {
+          "name": "daily_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_streak": {
+          "name": "message_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "announced_year": {
+          "name": "announced_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "user_house_monthly_points_idx": {
+          "name": "user_house_monthly_points_idx",
+          "columns": [
+            {
+              "expression": "house",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "monthly_points",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.voice_session": {
+      "name": "voice_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_tracked": {
+          "name": "is_tracked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "EXTRACT(EPOCH FROM (left_at - joined_at))",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "voice_session_discord_id_left_at_idx": {
+          "name": "voice_session_discord_id_left_at_idx",
+          "columns": [
+            {
+              "expression": "discord_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "left_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "voice_session_discord_id_user_discord_id_fk": {
+          "name": "voice_session_discord_id_user_discord_id_fk",
+          "tableFrom": "voice_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "discord_id"
+          ],
+          "columnsTo": [
+            "discord_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.house": {
+      "name": "house",
+      "schema": "public",
+      "values": [
+        "Gryffindor",
+        "Hufflepuff",
+        "Ravenclaw",
+        "Slytherin"
+      ]
+    },
+    "public.submission_status": {
+      "name": "submission_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPROVED",
+        "REJECTED",
+        "CANCELED"
+      ]
+    },
+    "public.submission_type": {
+      "name": "submission_type",
+      "schema": "public",
+      "values": [
+        "NEW",
+        "COMPLETED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1776816371937,
       "tag": "0032_low_korg",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1780776799267,
+      "tag": "0033_add_user_left_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -11,6 +11,7 @@ export const OpId = {
   vc: () => genOpId("vc"),
   rst: () => genOpId("rst"),
   msg: () => genOpId("msg"),
+  mbr: () => genOpId("mbr"),
   vcscan: () => genOpId("vcscan"),
   start: () => genOpId("start"),
   shtdwn: () => genOpId("shtdwn"),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,6 +28,9 @@ export const userTable = pgTable("user", {
   house: houseEnum(),
   timezone: varchar({ length: 50 }).default("UTC").notNull(),
   lastDailyReset: timestamp().defaultNow().notNull(),
+  // Set when the member leaves the guild; used on rejoin to decide which stats
+  // are stale. Null while the member is present.
+  leftAt: timestamp(),
 
   // Score fields
   dailyPoints: integer().default(0).notNull(),

--- a/src/discord/events/guildMemberAdd/index.ts
+++ b/src/discord/events/guildMemberAdd/index.ts
@@ -1,7 +1,7 @@
 import type { GuildMember } from "discord.js";
 import dayjs from "dayjs";
 import { eq } from "drizzle-orm";
-import { db } from "@/db/db.ts";
+import { db, getMonthStartDate } from "@/db/db.ts";
 import { userTable } from "@/db/schema.ts";
 import { wrapWithAlerting } from "@/discord/utils/alerting.ts";
 import { updateMessageStreakInNickname } from "@/discord/core/nicknameStreak.ts";
@@ -60,9 +60,13 @@ export async function execute(member: GuildMember) {
       updates.messageStreak = newStreak;
     }
 
-    // Different month → monthly window is stale: mirror what a monthly reset
-    // would have done to them had they been present.
-    if (!now.isSame(reference, "month")) {
+    // Monthly resets are a manual admin action recorded as a timestamp, not a
+    // calendar boundary. So compare the actual instants: if they left before the
+    // most recent monthly reset, that reset happened while they were away and
+    // their monthly stats are stale. (Instant comparison, so timezone / the
+    // window right before 00:00 UTC doesn't matter.)
+    const lastMonthlyReset = await getMonthStartDate();
+    if (reference.isBefore(lastMonthlyReset)) {
       updates.monthlyPoints = 0;
       updates.monthlyVoiceTime = 0;
       updates.announcedYear = 0;

--- a/src/discord/events/guildMemberAdd/index.ts
+++ b/src/discord/events/guildMemberAdd/index.ts
@@ -44,22 +44,14 @@ export async function execute(member: GuildMember) {
     let newStreak = user.messageStreak;
 
     // Different local day → daily window is stale: start a fresh day and settle
-    // the streak the same way the daily-reset cron would have.
+    // the streak. The last active day still counts (+1) if it met the threshold
+    // and they return the very next day; otherwise the chain is broken (a
+    // fully-absent day, or a last day below threshold). No booster handling is
+    // needed: leaving the guild ends the boost, so a member is never boosting at
+    // the moment they rejoin.
     if (daysMissed >= 1) {
       const metThreshold = user.dailyMessages >= MIN_DAILY_MESSAGES_FOR_STREAK;
-      const isBooster = member.premiumSince !== null;
-
-      if (isBooster) {
-        // Boosters keep their streak on below-threshold days; their last active
-        // day still increments it when they met the threshold.
-        newStreak = metThreshold ? user.messageStreak + 1 : user.messageStreak;
-      } else if (daysMissed === 1 && metThreshold) {
-        // Left having met the threshold and back the very next day → it counts.
-        newStreak = user.messageStreak + 1;
-      } else {
-        // A fully-absent day (0 messages) breaks the streak.
-        newStreak = 0;
-      }
+      newStreak = daysMissed === 1 && metThreshold ? user.messageStreak + 1 : 0;
 
       updates.lastDailyReset = new Date();
       updates.dailyPoints = 0;

--- a/src/discord/events/guildMemberAdd/index.ts
+++ b/src/discord/events/guildMemberAdd/index.ts
@@ -1,0 +1,67 @@
+import type { GuildMember } from "discord.js";
+import dayjs from "dayjs";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/db.ts";
+import { userTable } from "@/db/schema.ts";
+import { wrapWithAlerting } from "@/discord/utils/alerting.ts";
+import { createLogger } from "@/common/logging/logger.ts";
+
+const log = createLogger("Member");
+
+// When a member rejoins, their stored stats may be stale (a daily/monthly
+// boundary could have passed while they were gone). Without this, the next
+// hourly reset tick would wipe their streak/points at an arbitrary hour instead
+// of their real local midnight. We compare the moment they left against now (in
+// their timezone) and only reset the windows that actually rolled over.
+export async function execute(member: GuildMember) {
+  if (member.user.bot) return;
+
+  await wrapWithAlerting(async () => {
+    const [user] = await db
+      .select({
+        timezone: userTable.timezone,
+        leftAt: userTable.leftAt,
+        lastDailyReset: userTable.lastDailyReset,
+      })
+      .from(userTable)
+      .where(eq(userTable.discordId, member.id));
+
+    // Brand-new member: no row yet. It is created with now() on first activity,
+    // which already starts a correct daily/monthly window.
+    if (!user) return;
+
+    // Reference = when they left. Fall back to last reset for rows that predate
+    // leave-tracking (e.g. members who left before this feature existed).
+    const reference = dayjs(user.leftAt ?? user.lastDailyReset).tz(user.timezone);
+    const now = dayjs().tz(user.timezone);
+
+    const updates: Partial<typeof userTable.$inferInsert> = { leftAt: null };
+
+    // Different local day → daily window is stale: start a fresh day now and
+    // reset the message streak.
+    if (!now.isSame(reference, "day")) {
+      updates.lastDailyReset = new Date();
+      updates.dailyPoints = 0;
+      updates.dailyVoiceTime = 0;
+      updates.dailyMessages = 0;
+      updates.messageStreak = 0;
+    }
+
+    // Different month → monthly window is stale: mirror what a monthly reset
+    // would have done to them had they been present.
+    if (!now.isSame(reference, "month")) {
+      updates.monthlyPoints = 0;
+      updates.monthlyVoiceTime = 0;
+      updates.announcedYear = 0;
+    }
+
+    await db.update(userTable).set(updates).where(eq(userTable.discordId, member.id));
+
+    log.info("Member rejoined", {
+      userId: member.id,
+      user: member.user.username,
+      resetDaily: updates.lastDailyReset !== undefined,
+      resetMonthly: updates.monthlyPoints !== undefined,
+    });
+  }, `Guild member add for ${member.user.username} (${member.id})`);
+}

--- a/src/discord/events/guildMemberAdd/index.ts
+++ b/src/discord/events/guildMemberAdd/index.ts
@@ -1,7 +1,7 @@
 import type { GuildMember } from "discord.js";
 import dayjs from "dayjs";
 import { eq } from "drizzle-orm";
-import { db, getMonthStartDate } from "@/db/db.ts";
+import { db } from "@/db/db.ts";
 import { userTable } from "@/db/schema.ts";
 import { wrapWithAlerting } from "@/discord/utils/alerting.ts";
 import { updateMessageStreakInNickname } from "@/discord/core/nicknameStreak.ts";
@@ -10,11 +10,13 @@ import { createLogger } from "@/common/logging/logger.ts";
 
 const log = createLogger("Member");
 
-// When a member rejoins, their stored stats may be stale (a daily/monthly
+// When a member rejoins, their stored daily stats may be stale (a local-midnight
 // boundary could have passed while they were gone). Without this, the next
 // hourly reset tick would settle their streak/points at an arbitrary hour
 // instead of their real local midnight. We compare the moment they left against
-// now (in their timezone) and only reset the windows that actually rolled over.
+// now (in their timezone) and start a fresh day only if it actually rolled over.
+// Monthly stats are left alone — the monthly reset command zeroes every row,
+// including members who have left.
 export async function execute(member: GuildMember) {
   if (member.user.bot) return;
 
@@ -60,17 +62,9 @@ export async function execute(member: GuildMember) {
       updates.messageStreak = newStreak;
     }
 
-    // Monthly resets are a manual admin action recorded as a timestamp, not a
-    // calendar boundary. So compare the actual instants: if they left before the
-    // most recent monthly reset, that reset happened while they were away and
-    // their monthly stats are stale. (Instant comparison, so timezone / the
-    // window right before 00:00 UTC doesn't matter.)
-    const lastMonthlyReset = await getMonthStartDate();
-    if (reference.isBefore(lastMonthlyReset)) {
-      updates.monthlyPoints = 0;
-      updates.monthlyVoiceTime = 0;
-      updates.announcedYear = 0;
-    }
+    // Monthly stats are intentionally not touched here: the monthly reset
+    // command zeroes every user row (including members who have left), so an
+    // absent member's monthly stats are already correct on rejoin.
 
     await db.update(userTable).set(updates).where(eq(userTable.discordId, member.id));
 
@@ -78,12 +72,6 @@ export async function execute(member: GuildMember) {
       await updateMessageStreakInNickname(member, newStreak);
     }
 
-    log.info("Member rejoined", {
-      userId: member.id,
-      user: member.user.username,
-      daysMissed,
-      streak: newStreak,
-      resetMonthly: updates.monthlyPoints !== undefined,
-    });
+    log.info("Member rejoined", { userId: member.id, user: member.user.username, daysMissed, streak: newStreak });
   }, `Guild member add for ${member.user.username} (${member.id})`);
 }

--- a/src/discord/events/guildMemberAdd/index.ts
+++ b/src/discord/events/guildMemberAdd/index.ts
@@ -4,15 +4,17 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db/db.ts";
 import { userTable } from "@/db/schema.ts";
 import { wrapWithAlerting } from "@/discord/utils/alerting.ts";
+import { updateMessageStreakInNickname } from "@/discord/core/nicknameStreak.ts";
+import { MIN_DAILY_MESSAGES_FOR_STREAK } from "@/common/constants.ts";
 import { createLogger } from "@/common/logging/logger.ts";
 
 const log = createLogger("Member");
 
 // When a member rejoins, their stored stats may be stale (a daily/monthly
 // boundary could have passed while they were gone). Without this, the next
-// hourly reset tick would wipe their streak/points at an arbitrary hour instead
-// of their real local midnight. We compare the moment they left against now (in
-// their timezone) and only reset the windows that actually rolled over.
+// hourly reset tick would settle their streak/points at an arbitrary hour
+// instead of their real local midnight. We compare the moment they left against
+// now (in their timezone) and only reset the windows that actually rolled over.
 export async function execute(member: GuildMember) {
   if (member.user.bot) return;
 
@@ -22,6 +24,8 @@ export async function execute(member: GuildMember) {
         timezone: userTable.timezone,
         leftAt: userTable.leftAt,
         lastDailyReset: userTable.lastDailyReset,
+        dailyMessages: userTable.dailyMessages,
+        messageStreak: userTable.messageStreak,
       })
       .from(userTable)
       .where(eq(userTable.discordId, member.id));
@@ -34,17 +38,34 @@ export async function execute(member: GuildMember) {
     // leave-tracking (e.g. members who left before this feature existed).
     const reference = dayjs(user.leftAt ?? user.lastDailyReset).tz(user.timezone);
     const now = dayjs().tz(user.timezone);
+    const daysMissed = now.startOf("day").diff(reference.startOf("day"), "day");
 
     const updates: Partial<typeof userTable.$inferInsert> = { leftAt: null };
+    let newStreak = user.messageStreak;
 
-    // Different local day → daily window is stale: start a fresh day now and
-    // reset the message streak.
-    if (!now.isSame(reference, "day")) {
+    // Different local day → daily window is stale: start a fresh day and settle
+    // the streak the same way the daily-reset cron would have.
+    if (daysMissed >= 1) {
+      const metThreshold = user.dailyMessages >= MIN_DAILY_MESSAGES_FOR_STREAK;
+      const isBooster = member.premiumSince !== null;
+
+      if (isBooster) {
+        // Boosters keep their streak on below-threshold days; their last active
+        // day still increments it when they met the threshold.
+        newStreak = metThreshold ? user.messageStreak + 1 : user.messageStreak;
+      } else if (daysMissed === 1 && metThreshold) {
+        // Left having met the threshold and back the very next day → it counts.
+        newStreak = user.messageStreak + 1;
+      } else {
+        // A fully-absent day (0 messages) breaks the streak.
+        newStreak = 0;
+      }
+
       updates.lastDailyReset = new Date();
       updates.dailyPoints = 0;
       updates.dailyVoiceTime = 0;
       updates.dailyMessages = 0;
-      updates.messageStreak = 0;
+      updates.messageStreak = newStreak;
     }
 
     // Different month → monthly window is stale: mirror what a monthly reset
@@ -57,10 +78,15 @@ export async function execute(member: GuildMember) {
 
     await db.update(userTable).set(updates).where(eq(userTable.discordId, member.id));
 
+    if (newStreak !== user.messageStreak) {
+      await updateMessageStreakInNickname(member, newStreak);
+    }
+
     log.info("Member rejoined", {
       userId: member.id,
       user: member.user.username,
-      resetDaily: updates.lastDailyReset !== undefined,
+      daysMissed,
+      streak: newStreak,
       resetMonthly: updates.monthlyPoints !== undefined,
     });
   }, `Guild member add for ${member.user.username} (${member.id})`);

--- a/src/discord/events/guildMemberRemove/index.ts
+++ b/src/discord/events/guildMemberRemove/index.ts
@@ -1,0 +1,20 @@
+import type { GuildMember, PartialGuildMember } from "discord.js";
+import { eq } from "drizzle-orm";
+import { db } from "@/db/db.ts";
+import { userTable } from "@/db/schema.ts";
+import { wrapWithAlerting } from "@/discord/utils/alerting.ts";
+import { createLogger } from "@/common/logging/logger.ts";
+
+const log = createLogger("Member");
+
+// Record when a member leaves so that, on a later rejoin, we can tell which of
+// their stats (daily/monthly/streak) have gone stale while they were away.
+export async function execute(member: GuildMember | PartialGuildMember) {
+  if (member.user.bot) return;
+
+  await wrapWithAlerting(async () => {
+    await db.update(userTable).set({ leftAt: new Date() }).where(eq(userTable.discordId, member.id));
+  }, `Guild member remove for ${member.user.username} (${member.id})`);
+
+  log.info("Member left", { userId: member.id, user: member.user.username });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ import * as ClientReady from "@/discord/events/clientReady/index.ts";
 import * as InteractionCreate from "@/discord/events/interactionCreate/index.ts";
 import * as MessageCreate from "@/discord/events/messageCreate/index.ts";
 import * as MessageReactionAdd from "@/discord/events/messageReactionAdd/index.ts";
+import * as GuildMemberAdd from "@/discord/events/guildMemberAdd/index.ts";
+import * as GuildMemberRemove from "@/discord/events/guildMemberRemove/index.ts";
 import { alertOwner } from "@/discord/utils/alerting.ts";
 import { interactionExecutionTimer, resetExecutionTimer, voiceSessionExecutionTimer } from "@/common/logging/monitoring.ts";
 import { commands } from "@/discord/commands.ts";
@@ -58,6 +60,8 @@ function registerEvents(client: Client) {
   client.on(Events.VoiceStateUpdate, (a, b) => void runOpId(OpId.vc(), () => VoiceStateUpdate.execute(a, b)));
   client.on(Events.MessageCreate, (m) => void runOpId(OpId.msg(), () => MessageCreate.execute(m)));
   client.on(Events.MessageReactionAdd, (r, u) => void runOpId(OpId.msg(), async () => MessageReactionAdd.execute(r, u)));
+  client.on(Events.GuildMemberAdd, (m) => void runOpId(OpId.mbr(), () => GuildMemberAdd.execute(m)));
+  client.on(Events.GuildMemberRemove, (m) => void runOpId(OpId.mbr(), () => GuildMemberRemove.execute(m)));
   client.on(Events.Debug, (info) => log.debug(info));
   client.on(Events.Warn, (info) => log.warn(info));
   client.on(Events.Error, (error) => {


### PR DESCRIPTION
A returning member kept a months-old last_daily_reset, so the next
hourly reset cron wiped their streak/points at an arbitrary hour rather
than at their local midnight.

- Add nullable user.left_at, written on GuildMemberRemove
- On GuildMemberAdd, compare leave time (fallback last_daily_reset) to
  now in the user's timezone: reset daily stats + streak on a new day,
  monthly stats on a new month, and clear left_at