### PR TITLE
Add OpenRouter-based AI year promotion announcements with fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,11 @@ JOURNAL_CHANNEL_ID=your_journal_channel_id_here
 COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
+# OpenRouter AI year promotion announcements (optional)
+# Uses a free model by default; override only if you know the model is available to your account.
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+OPENROUTER_MODEL=google/gemma-3n-e4b-it:free
+OPENROUTER_SITE_URL=https://schnabel.dev
+
 # Analytics secret to bypass mystery mode (optional)
 MYSTERY_SECRET=your_secret_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,9 @@ Required in `.env` (see `.env.example`):
 - `EXCLUDE_VOICE_CHANNEL_IDS` - Voice channels to exclude from tracking
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
+- `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements through OpenRouter
+- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for year promotion announcements; defaults to `google/gemma-3n-e4b-it:free`
+- `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern
 

--- a/src/discord/events/voiceStateUpdate/yearRole.ts
+++ b/src/discord/events/voiceStateUpdate/yearRole.ts
@@ -4,10 +4,18 @@ import { userTable } from "@/db/schema.ts";
 import { createLogger } from "../../../common/logging/logger.ts";
 import assert from "node:assert";
 import type { House, UpdateMemberParams } from "@/common/types.ts";
-import { HOUSE_COLORS, YEAR_MESSAGES, YEAR_THRESHOLDS_HOURS } from "../../../common/constants.ts";
+import {
+  HOUSE_COLORS,
+  YEAR_MESSAGES,
+  YEAR_THRESHOLDS_HOURS,
+} from "../../../common/constants.ts";
 import { getYearFromMonthlyVoiceTime } from "@/discord/core/year.ts";
 import { eq, isNotNull } from "drizzle-orm";
 import { updateMember } from "@/discord/utils/updateMember.ts";
+import {
+  generateYearAnnouncement,
+  isOpenRouterConfigured,
+} from "@/services/openRouterService.ts";
 
 const log = createLogger("YearRole");
 
@@ -16,7 +24,11 @@ const YEAR_ANNOUNCEMENT_CHANNEL_ID = process.env.YEAR_ANNOUNCEMENT_CHANNEL_ID;
 
 export async function announceYearPromotion(
   member: GuildMember,
-  user: { monthlyVoiceTime: number; house: House | null; announcedYear: number } | null,
+  user: {
+    monthlyVoiceTime: number;
+    house: House | null;
+    announcedYear: number;
+  } | null,
 ): Promise<void> {
   if (!user?.house) return;
   const year = getYearFromMonthlyVoiceTime(user.monthlyVoiceTime);
@@ -30,7 +42,9 @@ export async function announceYearPromotion(
   assert(hours, `No hours threshold configured for year ${year}`);
 
   try {
-    const channel = await member.guild.channels.fetch(YEAR_ANNOUNCEMENT_CHANNEL_ID);
+    const channel = await member.guild.channels.fetch(
+      YEAR_ANNOUNCEMENT_CHANNEL_ID,
+    );
     if (!channel?.isTextBased()) {
       log.error("Year announcement channel is not text-based", ctx);
       return;
@@ -38,19 +52,79 @@ export async function announceYearPromotion(
 
     await channel.send({
       content: `Congratulations ${member.toString()}!`,
-      embeds: [{
-        title: "New Activity Rank Attained!",
-        description: YEAR_MESSAGES[user.house]
-          .replace("{ROLE}", roleMention(roleId))
-          .replace("{HOURS}", hours.toString() + (hours === 1 ? " hour" : " hours")),
-        color: HOUSE_COLORS[user.house],
-      }],
+      embeds: [
+        {
+          title: "New Activity Rank Attained!",
+          description: await getYearAnnouncementDescription({
+            house: user.house,
+            roleId,
+            hours,
+            member,
+            year,
+            ctx,
+          }),
+          color: HOUSE_COLORS[user.house],
+        },
+      ],
     });
 
-    await db.update(userTable).set({ announcedYear: year }).where(eq(userTable.discordId, member.id));
+    await db
+      .update(userTable)
+      .set({ announcedYear: year })
+      .where(eq(userTable.discordId, member.id));
   } catch (error) {
     log.error("Failed to send year promotion announcement:", ctx, error);
   }
+}
+
+async function getYearAnnouncementDescription({
+  house,
+  roleId,
+  hours,
+  member,
+  year,
+  ctx,
+}: {
+  house: House;
+  roleId: string;
+  hours: number;
+  member: GuildMember;
+  year: number;
+  ctx: { userId: string; username: string };
+}): Promise<string> {
+  const role = roleMention(roleId);
+  const hourText = hours.toString() + (hours === 1 ? " hour" : " hours");
+
+  if (!isOpenRouterConfigured()) {
+    return formatFallbackYearMessage(house, role, hourText);
+  }
+
+  try {
+    return await generateYearAnnouncement({
+      house,
+      roleMention: role,
+      hours: hourText,
+      year,
+      username: member.displayName,
+    });
+  } catch (error) {
+    log.warn(
+      "Falling back to static year promotion announcement after OpenRouter failure",
+      {
+        ...ctx,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return formatFallbackYearMessage(house, role, hourText);
+  }
+}
+
+function formatFallbackYearMessage(
+  house: House,
+  role: string,
+  hours: string,
+): string {
+  return YEAR_MESSAGES[house].replace("{ROLE}", role).replace("{HOURS}", hours);
 }
 
 export function calculateYearRoles(
@@ -66,7 +140,9 @@ export function calculateYearRoles(
   const roleId = year === null ? null : YEAR_ROLE_IDS[year - 1];
 
   // Remove all year roles except target
-  const rolesToRemove = YEAR_ROLE_IDS.filter((id) => id !== roleId && member.roles.cache.has(id));
+  const rolesToRemove = YEAR_ROLE_IDS.filter(
+    (id) => id !== roleId && member.roles.cache.has(id),
+  );
   const rolesToAdd = roleId && !member.roles.cache.has(roleId) ? [roleId] : [];
 
   return { rolesToRemove, rolesToAdd };
@@ -76,7 +152,11 @@ export async function refreshAllYearRoles(guild: Guild): Promise<number> {
   if (YEAR_ROLE_IDS.length !== 7) return 0;
 
   const users = await db
-    .select({ discordId: userTable.discordId, monthlyVoiceTime: userTable.monthlyVoiceTime, house: userTable.house })
+    .select({
+      discordId: userTable.discordId,
+      monthlyVoiceTime: userTable.monthlyVoiceTime,
+      house: userTable.house,
+    })
     .from(userTable)
     .where(isNotNull(userTable.house));
   let updated = 0;
@@ -96,7 +176,11 @@ export async function refreshAllYearRoles(guild: Guild): Promise<number> {
   }
   await Promise.all(
     updates.map(async ({ member, roleUpdates }) => {
-      await updateMember({ member, reason: "Refreshing year roles", roleUpdates });
+      await updateMember({
+        member,
+        reason: "Refreshing year roles",
+        roleUpdates,
+      });
     }),
   );
   return updated;

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,0 +1,118 @@
+import type { House } from "@/common/types.ts";
+
+export const DEFAULT_OPENROUTER_MODEL = "google/gemma-3n-e4b-it:free";
+
+const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
+const MAX_ANNOUNCEMENT_LENGTH = 900;
+
+export interface YearAnnouncementRequest {
+  house: House;
+  roleMention: string;
+  hours: string;
+  year: number;
+  username: string;
+}
+
+export interface OpenRouterChatResponse {
+  choices?: {
+    message?: {
+      content?: string | null;
+    };
+  }[];
+  error?: {
+    message?: string;
+  };
+}
+
+export function isOpenRouterConfigured(): boolean {
+  return Boolean(process.env["OPENROUTER_API_KEY"]);
+}
+
+export function getOpenRouterModel(): string {
+  const model = process.env["OPENROUTER_MODEL"]?.trim();
+  return model === undefined || model.length === 0
+    ? DEFAULT_OPENROUTER_MODEL
+    : model;
+}
+
+export function buildYearAnnouncementPrompt({
+  house,
+  roleMention,
+  hours,
+  year,
+  username,
+}: YearAnnouncementRequest): string {
+  return [
+    "Write one short Discord embed description for a Hogwarts-themed productivity server.",
+    `Member: ${username}`,
+    `House: ${house}`,
+    `New activity rank: ${roleMention}`,
+    `Year level: ${year}`,
+    `Monthly voice-study milestone: ${hours}`,
+    "Requirements:",
+    `- Congratulate the member in a warm ${house} style without being sarcastic.`,
+    "- Mention the role and the milestone exactly once each.",
+    "- Keep it under 70 words.",
+    "- Do not include a title, heading, markdown table, hashtags, or roleplay dialogue.",
+  ].join("\n");
+}
+
+export function sanitizeAnnouncementContent(content: string): string {
+  return content
+    .replaceAll(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_ANNOUNCEMENT_LENGTH);
+}
+
+export async function generateYearAnnouncement(
+  request: YearAnnouncementRequest,
+): Promise<string> {
+  const apiKey = process.env["OPENROUTER_API_KEY"];
+  if (!apiKey) {
+    throw new Error(
+      "OpenRouter is not configured. Set OPENROUTER_API_KEY to enable AI year announcements.",
+    );
+  }
+
+  const referer = process.env["OPENROUTER_SITE_URL"] ?? "https://schnabel.dev";
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${apiKey}`);
+  headers.set("Content-Type", "application/json");
+  headers.set("HTTP-Referer", referer);
+  headers.set("X-Title", "Hogwarts Productivity Hub Bot");
+
+  const response = await fetch(OPENROUTER_API_URL, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: getOpenRouterModel(),
+      messages: [
+        {
+          role: "system",
+          content:
+            "You write concise, celebratory Discord announcements for a Hogwarts-themed productivity community.",
+        },
+        { role: "user", content: buildYearAnnouncementPrompt(request) },
+      ],
+      temperature: 0.8,
+      max_tokens: 140,
+    }),
+  });
+
+  const payload = (await response.json()) as OpenRouterChatResponse;
+  if (!response.ok) {
+    const errorMessage =
+      payload.error?.message ??
+      `OpenRouter request failed with status ${response.status}`;
+    throw new Error(errorMessage);
+  }
+
+  const content = sanitizeAnnouncementContent(
+    payload.choices?.[0]?.message?.content ?? "",
+  );
+  if (!content) {
+    throw new Error("OpenRouter returned an empty year announcement.");
+  }
+
+  return content;
+}

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildYearAnnouncementPrompt,
+  DEFAULT_OPENROUTER_MODEL,
+  generateYearAnnouncement,
+  getOpenRouterModel,
+  sanitizeAnnouncementContent,
+} from "@/services/openRouterService.ts";
+
+const request = {
+  house: "Ravenclaw" as const,
+  roleMention: "<@&year3>",
+  hours: "20 hours",
+  year: 3,
+  username: "Luna",
+};
+
+describe("openRouterService", () => {
+  it("builds house-specific year announcement prompts", () => {
+    const prompt = buildYearAnnouncementPrompt(request);
+
+    expect(prompt).toContain("House: Ravenclaw");
+    expect(prompt).toContain("New activity rank: <@&year3>");
+    expect(prompt).toContain("Monthly voice-study milestone: 20 hours");
+    expect(prompt).toContain("warm Ravenclaw style");
+  });
+
+  it("sanitizes long, whitespace-heavy announcement content", () => {
+    const content = sanitizeAnnouncementContent(
+      `  Great\n\twork   ${"x".repeat(1000)}`,
+    );
+
+    expect(content.startsWith("Great work")).toBe(true);
+    expect(content).toHaveLength(900);
+  });
+
+  it("defaults to a free OpenRouter model", () => {
+    vi.stubEnv("OPENROUTER_MODEL", "");
+
+    expect(getOpenRouterModel()).toBe(DEFAULT_OPENROUTER_MODEL);
+  });
+
+  it("returns sanitized year announcement content from OpenRouter", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: "  Well done, Ravenclaw!\nYou earned it. ",
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    await expect(generateYearAnnouncement(request)).resolves.toBe(
+      "Well done, Ravenclaw! You earned it.",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Enable optional AI-generated year promotion announcements to create more engaging, house-styled messages for member promotions.
- Provide a safe fallback to the existing static announcement text when OpenRouter is not configured or if the AI call fails.

### Description

- Added a new service `src/services/openRouterService.ts` that builds prompts, calls the OpenRouter API, sanitizes responses, and exposes `generateYearAnnouncement`, `isOpenRouterConfigured`, and `getOpenRouterModel` utilities.
- Integrated AI announcements into `src/discord/events/voiceStateUpdate/yearRole.ts` by using `generateYearAnnouncement` when `OPENROUTER_API_KEY` is set, and falling back to the original static `YEAR_MESSAGES` on error or when not configured.
- Updated `.env.example` to document and provide default values for `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, and `OPENROUTER_SITE_URL` and updated `AGENTS.md` to list these environment variables.
- Added unit tests `tests/openRouterService.test.ts` for prompt building, sanitization, model defaulting, and the network interaction by stubbing `fetch` and environment variables.

### Testing

- Ran Vitest for the new service tests via `vitest`, and `tests/openRouterService.test.ts` passed successfully.
- Confirmed the AI path is exercised by stubbing `fetch` and `OPENROUTER_API_KEY` in tests, and the fallback behavior is exercised when the API is not configured (covered by code paths and manual review).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fad6b54488333b60e24494e75d779)