### PR TITLE
Add OpenRouter-powered /explain command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ JOURNAL_CHANNEL_ID=your_journal_channel_id_here
 COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
-# OpenRouter AI year promotion announcements (optional)
+# OpenRouter AI features: year promotion announcements and /explain (optional)
 # Uses a free model by default; override only if you know the model is available to your account.
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 OPENROUTER_MODEL=openai/gpt-oss-120b:free

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ npx drizzle-kit generate   # Generate new migration from schema changes
 - `submit/` - Point submissions and reminders
 - `timezone.ts` - User timezone settings
 - `user.ts` - User profile/stats
+- `explain.ts` - AI explanations for member questions using OpenRouter
 
 Each command exports:
 
@@ -176,8 +177,8 @@ Required in `.env` (see `.env.example`):
 - `EXCLUDE_VOICE_CHANNEL_IDS` - Voice channels to exclude from tracking
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
-- `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements through OpenRouter
-- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for year promotion announcements; defaults to `openai/gpt-oss-120b:free`
+- `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
+- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openai/gpt-oss-120b:free`
 - `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -5,6 +5,7 @@ import submit from "./events/interactionCreate/submit/index.ts";
 import admin from "./events/interactionCreate/admin/index.ts";
 import scoreboard from "./events/interactionCreate/scoreboard/index.ts";
 import user from "./events/interactionCreate/user.ts";
+import explain from "./events/interactionCreate/explain.ts";
 
 export const commands = new Collection<string, Command>();
 
@@ -14,5 +15,6 @@ commands.set(timezoneCommand.data.name, timezoneCommand);
 commands.set(scoreboard.data.name, scoreboard);
 commands.set(admin.data.name, admin);
 commands.set(user.data.name, user);
+commands.set(explain.data.name, explain);
 
 commands.set(submit.data.name, submit);

--- a/src/discord/events/interactionCreate/explain.ts
+++ b/src/discord/events/interactionCreate/explain.ts
@@ -1,0 +1,76 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import type { Command } from "@/common/types.ts";
+import { BOT_COLORS } from "@/common/constants.ts";
+import { errorReply } from "@/discord/utils/interaction.ts";
+import { createLogger } from "@/common/logging/logger.ts";
+import { generateExplanation, isOpenRouterConfigured } from "@/services/openRouterService.ts";
+
+const log = createLogger("ExplainCommand");
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("explain")
+    .setDescription("Explain a concept or question with a light Hogwarts classroom style")
+    .addStringOption((option) =>
+      option
+        .setName("question")
+        .setDescription("The concept or question you want explained")
+        .setRequired(true),
+    ),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    const question = interaction.options.getString("question", true).trim();
+
+    if (question.length < 3) {
+      await errorReply(interaction, "Question Too Short", "Please ask a question with at least 3 characters.");
+      return;
+    }
+
+    if (question.length > 1000) {
+      await errorReply(interaction, "Question Too Long", "Please keep your question under 1,000 characters.");
+      return;
+    }
+
+    if (!isOpenRouterConfigured()) {
+      await errorReply(
+        interaction,
+        "AI Explanations Unavailable",
+        "OpenRouter is not configured yet. Please ask a professor to set `OPENROUTER_API_KEY` before using `/explain`.",
+      );
+      return;
+    }
+
+    await interaction.deferReply();
+
+    try {
+      const explanation = await generateExplanation({
+        question,
+        username: interaction.user.displayName,
+      });
+
+      await interaction.editReply({
+        embeds: [
+          {
+            color: BOT_COLORS.INFO,
+            title: "📚 Explanation from the Library",
+            description: explanation,
+            fields: [{ name: "Question", value: question.slice(0, 1024) }],
+            footer: { text: "AI-generated via OpenRouter. Double-check important facts." },
+          },
+        ],
+      });
+    } catch (error) {
+      log.warn("OpenRouter explanation failed", {
+        userId: interaction.user.id,
+        user: interaction.user.tag,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await errorReply(
+        interaction,
+        "Explanation Failed",
+        "The library portraits could not fetch an answer right now. Please try again later.",
+        { deferred: true },
+      );
+    }
+  },
+} as Command;

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -4,6 +4,7 @@ export const DEFAULT_OPENROUTER_MODEL = "openai/gpt-oss-120b:free";
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
+const MAX_EXPLANATION_LENGTH = 1900;
 
 export interface YearAnnouncementRequest {
   house: House;
@@ -11,6 +12,16 @@ export interface YearAnnouncementRequest {
   hours: string;
   year: number;
   username: string;
+}
+
+export interface ExplanationRequest {
+  question: string;
+  username: string;
+}
+
+export interface OpenRouterMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
 }
 
 export interface OpenRouterChatResponse {
@@ -57,6 +68,22 @@ export function buildYearAnnouncementPrompt({
   ].join("\n");
 }
 
+export function buildExplanationPrompt({ question, username }: ExplanationRequest): string {
+  return [
+    "Explain a concept or answer a question for a member of a Hogwarts-themed productivity Discord server.",
+    `Member: ${username}`,
+    `Question: ${question}`,
+    "Requirements:",
+    "- Be accurate, practical, and easy to understand.",
+    "- Use a light Hogwarts classroom flavor, such as lessons, libraries, spells, or houses, without heavy roleplay.",
+    "- Do not pretend to be a Harry Potter character or include roleplay dialogue.",
+    "- If the question is ambiguous, state the most likely interpretation and give a useful answer.",
+    "- If you are not sure, say so and suggest how the member can verify it.",
+    "- Keep the response under 350 words.",
+    "- Use Discord-friendly Markdown with short paragraphs or bullets when helpful.",
+  ].join("\n");
+}
+
 export function sanitizeAnnouncementContent(content: string): string {
   return content
     .replaceAll(/\s+/g, " ")
@@ -64,14 +91,34 @@ export function sanitizeAnnouncementContent(content: string): string {
     .slice(0, MAX_ANNOUNCEMENT_LENGTH);
 }
 
-export async function generateYearAnnouncement(
-  request: YearAnnouncementRequest,
-): Promise<string> {
+export function sanitizeExplanationContent(content: string): string {
+  return sanitizeOpenRouterContent(content, MAX_EXPLANATION_LENGTH);
+}
+
+function sanitizeOpenRouterContent(content: string, maxLength: number): string {
+  return content
+    .replaceAll(/[ \t]+/g, " ")
+    .replaceAll(/\n{3,}/g, "\n\n")
+    .trim()
+    .slice(0, maxLength);
+}
+
+async function generateOpenRouterContent({
+  messages,
+  maxTokens,
+  temperature,
+  emptyResponseMessage,
+  sanitizer,
+}: {
+  messages: OpenRouterMessage[];
+  maxTokens: number;
+  temperature: number;
+  emptyResponseMessage: string;
+  sanitizer: (content: string) => string;
+}): Promise<string> {
   const apiKey = process.env["OPENROUTER_API_KEY"];
   if (!apiKey) {
-    throw new Error(
-      "OpenRouter is not configured. Set OPENROUTER_API_KEY to enable AI year announcements.",
-    );
+    throw new Error("OpenRouter is not configured. Set OPENROUTER_API_KEY to enable AI responses.");
   }
 
   const referer = process.env["OPENROUTER_SITE_URL"] ?? "https://schnabel.dev";
@@ -86,16 +133,9 @@ export async function generateYearAnnouncement(
     headers,
     body: JSON.stringify({
       model: getOpenRouterModel(),
-      messages: [
-        {
-          role: "system",
-          content:
-            "You write concise, celebratory Discord announcements for a Hogwarts-themed productivity community.",
-        },
-        { role: "user", content: buildYearAnnouncementPrompt(request) },
-      ],
-      temperature: 0.8,
-      max_tokens: 140,
+      messages,
+      temperature,
+      max_tokens: maxTokens,
     }),
   });
 
@@ -107,12 +147,46 @@ export async function generateYearAnnouncement(
     throw new Error(errorMessage);
   }
 
-  const content = sanitizeAnnouncementContent(
-    payload.choices?.[0]?.message?.content ?? "",
-  );
+  const content = sanitizer(payload.choices?.[0]?.message?.content ?? "");
   if (!content) {
-    throw new Error("OpenRouter returned an empty year announcement.");
+    throw new Error(emptyResponseMessage);
   }
 
   return content;
+}
+
+export async function generateYearAnnouncement(
+  request: YearAnnouncementRequest,
+): Promise<string> {
+  return generateOpenRouterContent({
+    messages: [
+      {
+        role: "system",
+        content:
+          "You write concise, celebratory Discord announcements for a Hogwarts-themed productivity community.",
+      },
+      { role: "user", content: buildYearAnnouncementPrompt(request) },
+    ],
+    temperature: 0.8,
+    maxTokens: 140,
+    emptyResponseMessage: "OpenRouter returned an empty year announcement.",
+    sanitizer: sanitizeAnnouncementContent,
+  });
+}
+
+export async function generateExplanation(request: ExplanationRequest): Promise<string> {
+  return generateOpenRouterContent({
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a helpful tutor for a Hogwarts-themed productivity community. Explain clearly with a light magical-school style, but do not roleplay.",
+      },
+      { role: "user", content: buildExplanationPrompt(request) },
+    ],
+    temperature: 0.6,
+    maxTokens: 600,
+    emptyResponseMessage: "OpenRouter returned an empty explanation.",
+    sanitizer: sanitizeExplanationContent,
+  });
 }

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildExplanationPrompt,
   buildYearAnnouncementPrompt,
   DEFAULT_OPENROUTER_MODEL,
+  generateExplanation,
   generateYearAnnouncement,
   getOpenRouterModel,
   sanitizeAnnouncementContent,
+  sanitizeExplanationContent,
 } from "@/services/openRouterService.ts";
 
 const request = {
@@ -23,6 +26,26 @@ describe("openRouterService", () => {
     expect(prompt).toContain("New activity rank: <@&year3>");
     expect(prompt).toContain("Monthly voice-study milestone: 20 hours");
     expect(prompt).toContain("warm Ravenclaw style");
+  });
+
+  it("builds Hogwarts-style explanation prompts", () => {
+    const prompt = buildExplanationPrompt({
+      question: "What is spaced repetition?",
+      username: "Hermione",
+    });
+
+    expect(prompt).toContain("Question: What is spaced repetition?");
+    expect(prompt).toContain("light Hogwarts classroom flavor");
+    expect(prompt).toContain("Do not pretend to be a Harry Potter character");
+  });
+
+  it("sanitizes explanation content while preserving paragraph breaks", () => {
+    const content = sanitizeExplanationContent(
+      `  First   paragraph.\n\n\nSecond\tparagraph. ${"x".repeat(2000)}`,
+    );
+
+    expect(content).toContain("First paragraph.\n\nSecond paragraph.");
+    expect(content).toHaveLength(1900);
   });
 
   it("sanitizes long, whitespace-heavy announcement content", () => {
@@ -62,5 +85,29 @@ describe("openRouterService", () => {
     await expect(generateYearAnnouncement(request)).resolves.toBe(
       "Well done, Ravenclaw! You earned it.",
     );
+  });
+
+  it("returns sanitized explanation content from OpenRouter", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: "  Think of it like a study spell.\n\nReview it again later. ",
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).resolves.toBe("Think of it like a study spell.\n\nReview it again later.");
   });
 });


### PR DESCRIPTION
### Motivation
- Provide members a quick, Hogwarts-flavored explanation tool backed by the existing OpenRouter integration so the server can answer concept questions without heavy roleplay.

### Description
- Add a new slash command at `src/discord/events/interactionCreate/explain.ts` that accepts a `question` string, validates length, defers the reply, and returns an embed with the AI explanation and an advisory footer.
- Extend `src/services/openRouterService.ts` with reusable chat-completion plumbing plus `buildExplanationPrompt`, `sanitizeExplanationContent`, and `generateExplanation` helpers, and refactor year-announcement generation to reuse the same request machinery.
- Register the command in `src/discord/commands.ts` and update docs/config samples in `AGENTS.md` and `.env.example` to mention the new `/explain` feature.
- Add unit tests in `tests/openRouterService.test.ts` to cover explanation prompt building, sanitization, and sanitized OpenRouter responses.

### Testing
- Ran targeted tests with `pnpm test tests/openRouterService.test.ts` and full test suite with `pnpm test`, which passed (`116` tests passed and `1` skipped in the final run). 
- Ran type checking with `pnpm typecheck` and linting with `pnpm lint`, both of which succeeded (no blocking errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd13348188333b4b7f6e03111e64f)