### PR TITLE
Set default OpenRouter model to openrouter/free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ Required in `.env` (see `.env.example`):
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
 - `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
-- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openai/gpt-oss-120b:free`
+- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openrouter/free`
 - `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,6 +1,6 @@
 import type { House } from "@/common/types.ts";
 
-export const DEFAULT_OPENROUTER_MODEL = "openai/gpt-oss-120b:free";
+export const DEFAULT_OPENROUTER_MODEL = "openrouter/free";
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;


### PR DESCRIPTION
### Motivation
- Prefer the free OpenRouter router as the default model slug for AI-powered features so the repo uses `openrouter/free` by default.

### Description
- Update `DEFAULT_OPENROUTER_MODEL` in `src/services/openRouterService.ts` from `openai/gpt-oss-120b:free` to `openrouter/free` and update the `OPENROUTER_MODEL` default in `AGENTS.md` to match.

### Testing
- Ran `pnpm test -- --run tests/openRouterService.test.ts`, `pnpm typecheck`, and `pnpm lint`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd5801a6883338428d441032a3f98)