### PR TITLE
Improve OpenRouter integration: truncation, error handling, prompts, and tests

### DIFF
--- a/src/discord/events/interactionCreate/explain.ts
+++ b/src/discord/events/interactionCreate/explain.ts
@@ -3,14 +3,18 @@ import type { Command } from "@/common/types.ts";
 import { BOT_COLORS } from "@/common/constants.ts";
 import { errorReply } from "@/discord/utils/interaction.ts";
 import { createLogger } from "@/common/logging/logger.ts";
-import { generateExplanation, isOpenRouterConfigured } from "@/services/openRouterService.ts";
+import {
+  generateExplanation,
+  isOpenRouterConfigured,
+  OpenRouterError,
+} from "@/services/openRouterService.ts";
 
 const log = createLogger("ExplainCommand");
 
 export default {
   data: new SlashCommandBuilder()
     .setName("explain")
-    .setDescription("Explain a concept or question with a light Hogwarts classroom style")
+    .setDescription("Explain a concept or question")
     .addStringOption((option) =>
       option
         .setName("question")
@@ -52,9 +56,8 @@ export default {
         embeds: [
           {
             color: BOT_COLORS.INFO,
-            title: "📚 Explanation from the Library",
+            title: "Explanation",
             description: explanation,
-            fields: [{ name: "Question", value: question.slice(0, 1024) }],
             footer: { text: "AI-generated via OpenRouter. Double-check important facts." },
           },
         ],
@@ -65,10 +68,20 @@ export default {
         user: interaction.user.tag,
         error: error instanceof Error ? error.message : String(error),
       });
+      if (error instanceof OpenRouterError && error.status === 429) {
+        await errorReply(
+          interaction,
+          "OpenRouter Rate Limited",
+          "OpenRouter is rate limiting AI explanation requests right now (HTTP 429). Please wait a bit before trying `/explain` again.",
+          { deferred: true },
+        );
+        return;
+      }
+
       await errorReply(
         interaction,
         "Explanation Failed",
-        "The library portraits could not fetch an answer right now. Please try again later.",
+        "OpenRouter could not fetch an answer right now. Please try again later.",
         { deferred: true },
       );
     }

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -4,7 +4,8 @@ export const DEFAULT_OPENROUTER_MODEL = "openrouter/free";
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
-const MAX_EXPLANATION_LENGTH = 1900;
+const MAX_EXPLANATION_LENGTH = 4000;
+const TRUNCATION_NOTICE = "\n\n… (response shortened to fit Discord)";
 
 export interface YearAnnouncementRequest {
   house: House;
@@ -22,6 +23,16 @@ export interface ExplanationRequest {
 export interface OpenRouterMessage {
   role: "system" | "user" | "assistant";
   content: string;
+}
+
+export class OpenRouterError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "OpenRouterError";
+  }
 }
 
 export interface OpenRouterChatResponse {
@@ -70,13 +81,14 @@ export function buildYearAnnouncementPrompt({
 
 export function buildExplanationPrompt({ question, username }: ExplanationRequest): string {
   return [
-    "Explain a concept or answer a question for a member of a Hogwarts-themed productivity Discord server.",
+    "Explain a concept or answer a question for a Discord community member.",
     `Member: ${username}`,
     `Question: ${question}`,
     "Requirements:",
     "- Be accurate, practical, and easy to understand.",
-    "- Use a light Hogwarts classroom flavor, such as lessons, libraries, spells, or houses, without heavy roleplay.",
-    "- Do not pretend to be a Harry Potter character or include roleplay dialogue.",
+    "- Use a direct, helpful tone without roleplay or themed flavor.",
+    "- Do not use tables.",
+    "- Do not repeat the question in the response.",
     "- If the question is ambiguous, state the most likely interpretation and give a useful answer.",
     "- If you are not sure, say so and suggest how the member can verify it.",
     "- Keep the response under 350 words.",
@@ -96,11 +108,35 @@ export function sanitizeExplanationContent(content: string): string {
 }
 
 function sanitizeOpenRouterContent(content: string, maxLength: number): string {
-  return content
+  const sanitized = content
     .replaceAll(/[ \t]+/g, " ")
     .replaceAll(/\n{3,}/g, "\n\n")
-    .trim()
-    .slice(0, maxLength);
+    .trim();
+
+  if (sanitized.length <= maxLength) {
+    return sanitized;
+  }
+
+  return truncateContent(sanitized, maxLength);
+}
+
+function truncateContent(content: string, maxLength: number): string {
+  const maxContentLength = maxLength - TRUNCATION_NOTICE.length;
+  const truncated = content.slice(0, maxContentLength).trimEnd();
+  const sentenceBreak = Math.max(
+    truncated.lastIndexOf(". "),
+    truncated.lastIndexOf("! "),
+    truncated.lastIndexOf("? "),
+    truncated.lastIndexOf(".\n"),
+    truncated.lastIndexOf("!\n"),
+    truncated.lastIndexOf("?\n"),
+  );
+
+  if (sentenceBreak > maxContentLength * 0.75) {
+    return `${truncated.slice(0, sentenceBreak + 1).trimEnd()}${TRUNCATION_NOTICE}`;
+  }
+
+  return `${truncated}${TRUNCATION_NOTICE}`;
 }
 
 async function generateOpenRouterContent({
@@ -144,7 +180,7 @@ async function generateOpenRouterContent({
     const errorMessage =
       payload.error?.message ??
       `OpenRouter request failed with status ${response.status}`;
-    throw new Error(errorMessage);
+    throw new OpenRouterError(errorMessage, response.status);
   }
 
   const content = sanitizer(payload.choices?.[0]?.message?.content ?? "");
@@ -179,13 +215,12 @@ export async function generateExplanation(request: ExplanationRequest): Promise<
     messages: [
       {
         role: "system",
-        content:
-          "You are a helpful tutor for a Hogwarts-themed productivity community. Explain clearly with a light magical-school style, but do not roleplay.",
+        content: "You are a helpful tutor. Explain clearly and directly without roleplay or themed flavor.",
       },
       { role: "user", content: buildExplanationPrompt(request) },
     ],
     temperature: 0.6,
-    maxTokens: 600,
+    maxTokens: 1000,
     emptyResponseMessage: "OpenRouter returned an empty explanation.",
     sanitizer: sanitizeExplanationContent,
   });

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -6,6 +6,7 @@ import {
   generateExplanation,
   generateYearAnnouncement,
   getOpenRouterModel,
+  OpenRouterError,
   sanitizeAnnouncementContent,
   sanitizeExplanationContent,
 } from "@/services/openRouterService.ts";
@@ -28,24 +29,30 @@ describe("openRouterService", () => {
     expect(prompt).toContain("warm Ravenclaw style");
   });
 
-  it("builds Hogwarts-style explanation prompts", () => {
+  it("builds direct explanation prompts", () => {
     const prompt = buildExplanationPrompt({
       question: "What is spaced repetition?",
       username: "Hermione",
     });
 
     expect(prompt).toContain("Question: What is spaced repetition?");
-    expect(prompt).toContain("light Hogwarts classroom flavor");
-    expect(prompt).toContain("Do not pretend to be a Harry Potter character");
+    expect(prompt).toContain("direct, helpful tone without roleplay or themed flavor");
+    expect(prompt).toContain("Do not use tables");
+    expect(prompt).toContain("Do not repeat the question in the response");
   });
 
   it("sanitizes explanation content while preserving paragraph breaks", () => {
-    const content = sanitizeExplanationContent(
-      `  First   paragraph.\n\n\nSecond\tparagraph. ${"x".repeat(2000)}`,
-    );
+    const content = sanitizeExplanationContent("  First   paragraph.\n\n\nSecond\tparagraph. ");
 
-    expect(content).toContain("First paragraph.\n\nSecond paragraph.");
-    expect(content).toHaveLength(1900);
+    expect(content).toBe("First paragraph.\n\nSecond paragraph.");
+  });
+
+  it("marks overlong explanation content as shortened instead of silently cutting off", () => {
+    const longContent = `First sentence. Second sentence. ${"x".repeat(5000)}`;
+    const content = sanitizeExplanationContent(longContent);
+
+    expect(content).toHaveLength(4000);
+    expect(content).toContain("response shortened to fit Discord");
   });
 
   it("sanitizes long, whitespace-heavy announcement content", () => {
@@ -98,7 +105,7 @@ describe("openRouterService", () => {
             choices: [
               {
                 message: {
-                  content: "  Think of it like a study spell.\n\nReview it again later. ",
+                  content: "  Review the idea once, then revisit it later.\n\nSpace reviews out over time. ",
                 },
               },
             ],
@@ -108,6 +115,29 @@ describe("openRouterService", () => {
 
     await expect(
       generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
-    ).resolves.toBe("Think of it like a study spell.\n\nReview it again later.");
+    ).resolves.toBe("Review the idea once, then revisit it later.\n\nSpace reviews out over time.");
+  });
+
+  it("throws OpenRouterError with status for failed OpenRouter responses", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: () =>
+          Promise.resolve({
+            error: { message: "Rate limit exceeded" },
+          }),
+      }),
+    );
+
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).rejects.toMatchObject({
+      name: "OpenRouterError",
+      message: "Rate limit exceeded",
+      status: 429,
+    } satisfies Partial<OpenRouterError>);
   });
 });


### PR DESCRIPTION
### Motivation
- Make AI responses more robust by handling OpenRouter errors explicitly and clearly reporting rate limits.
- Prevent silently cutting off long explanations and preserve readable sentence boundaries when truncating.
- Simplify and depersonalize explanation prompts away from Hogwarts flavor and tighten output limits/formatting requirements.

### Description
- Introduce an `OpenRouterError` class and throw it on non-OK OpenRouter responses so callers can inspect HTTP status codes.
- Increase `MAX_EXPLANATION_LENGTH` to 4000 and add a truncation pipeline that appends a notice and prefers ending at sentence boundaries via `truncateContent`.
- Consolidate sanitization logic in `sanitizeOpenRouterContent`, preserving paragraphs and trimming whitespace; add `TRUNCATION_NOTICE` constant.
- Update explanation prompts and system message to remove themed roleplay, forbid tables, and request not to repeat the question; increase `maxTokens` for explanations from 600 to 1000.
- Update the `/explain` command to change the embed title, remove the question field, and handle `OpenRouterError` with a specific 429 rate-limit reply.
- Adjust error copy to reference OpenRouter where appropriate.
- Update unit tests in `tests/openRouterService.test.ts` to cover prompt changes, sanitization behavior, truncation notice, and the new `OpenRouterError` behavior.

### Testing
- Ran unit tests with `pnpm test` (Vitest) focusing on `tests/openRouterService.test.ts` and related suites; all tests passed.
- Added tests that validate sanitization and truncation behavior, updated prompt expectations, and assert that a 429 response produces an `OpenRouterError` with `status: 429` which all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fd79b120883339b4d58353c4f24c8)