### PR TITLE
Show resolved model in explain footer

### DIFF
--- a/src/discord/events/interactionCreate/explain.ts
+++ b/src/discord/events/interactionCreate/explain.ts
@@ -57,8 +57,8 @@ export default {
           {
             color: BOT_COLORS.INFO,
             title: "Explanation",
-            description: explanation,
-            footer: { text: "AI-generated via OpenRouter. Double-check important facts." },
+            description: explanation.content,
+            footer: { text: `Model: ${explanation.model}. Double-check important facts.` },
           },
         ],
       });

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -36,6 +36,7 @@ export class OpenRouterError extends Error {
 }
 
 export interface OpenRouterChatResponse {
+  model?: string;
   choices?: {
     message?: {
       content?: string | null;
@@ -44,6 +45,11 @@ export interface OpenRouterChatResponse {
   error?: {
     message?: string;
   };
+}
+
+export interface GeneratedOpenRouterContent {
+  content: string;
+  model: string;
 }
 
 export function isOpenRouterConfigured(): boolean {
@@ -151,7 +157,7 @@ async function generateOpenRouterContent({
   temperature: number;
   emptyResponseMessage: string;
   sanitizer: (content: string) => string;
-}): Promise<string> {
+}): Promise<GeneratedOpenRouterContent> {
   const apiKey = process.env["OPENROUTER_API_KEY"];
   if (!apiKey) {
     throw new Error("OpenRouter is not configured. Set OPENROUTER_API_KEY to enable AI responses.");
@@ -188,13 +194,16 @@ async function generateOpenRouterContent({
     throw new Error(emptyResponseMessage);
   }
 
-  return content;
+  return {
+    content,
+    model: payload.model?.trim() ? payload.model.trim() : getOpenRouterModel(),
+  };
 }
 
 export async function generateYearAnnouncement(
   request: YearAnnouncementRequest,
 ): Promise<string> {
-  return generateOpenRouterContent({
+  const result = await generateOpenRouterContent({
     messages: [
       {
         role: "system",
@@ -208,9 +217,11 @@ export async function generateYearAnnouncement(
     emptyResponseMessage: "OpenRouter returned an empty year announcement.",
     sanitizer: sanitizeAnnouncementContent,
   });
+
+  return result.content;
 }
 
-export async function generateExplanation(request: ExplanationRequest): Promise<string> {
+export async function generateExplanation(request: ExplanationRequest): Promise<GeneratedOpenRouterContent> {
   return generateOpenRouterContent({
     messages: [
       {

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -102,6 +102,7 @@ describe("openRouterService", () => {
         ok: true,
         json: () =>
           Promise.resolve({
+            model: "test/free-model",
             choices: [
               {
                 message: {
@@ -115,7 +116,38 @@ describe("openRouterService", () => {
 
     await expect(
       generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
-    ).resolves.toBe("Review the idea once, then revisit it later.\n\nSpace reviews out over time.");
+    ).resolves.toEqual({
+      content: "Review the idea once, then revisit it later.\n\nSpace reviews out over time.",
+      model: "test/free-model",
+    });
+  });
+
+  it("falls back to the requested model when the response omits a model", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubEnv("OPENROUTER_MODEL", "custom/requested-model");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [
+              {
+                message: {
+                  content: "Fallback model label.",
+                },
+              },
+            ],
+          }),
+      }),
+    );
+
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).resolves.toEqual({
+      content: "Fallback model label.",
+      model: "custom/requested-model",
+    });
   });
 
   it("throws OpenRouterError with status for failed OpenRouter responses", async () => {


### PR DESCRIPTION
### Motivation
- Surface the actual model label used for `/explain` responses in the embed footer so users can see which model produced the explanation while removing the explicit provider name from the footer.

### Description
- Change `generateOpenRouterContent` to return both the sanitized `content` and the resolved `model` (with fallback to `getOpenRouterModel()` when the API omits a model). 
- Update `generateExplanation` to return the `GeneratedOpenRouterContent` object and keep `generateYearAnnouncement` returning only the announcement string. 
- Update the `/explain` handler to use `explanation.content` for the embed description and set the footer text to `Model: ${explanation.model}. Double-check important facts.` (no provider name). 
- Add/adjust tests in `tests/openRouterService.test.ts` to assert returned `content` and `model` and to verify fallback behavior when the response omits a model.

### Testing
- Ran unit tests with `pnpm test --run` and `pnpm test tests/openRouterService.test.ts --run`, all tests passed. 
- Ran lint and type checks with `pnpm lint` and `pnpm typecheck`, both succeeded. 
- Verified the adjusted tests for model labels and fallback behavior passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fdd70fa0083338938ddf6933254aa)