### PR TITLE
Send inline OpenRouter free model list and remove OPENROUTER_MODEL option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,8 @@ COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
 # OpenRouter AI features: year promotion announcements and /explain (optional)
-# Uses a free model by default; override only if you know the model is available to your account.
+# Uses an inline free model fallback list to avoid openrouter/free routing to unsuitable models.
 OPENROUTER_API_KEY=your_openrouter_api_key_here
-OPENROUTER_MODEL=openai/gpt-oss-120b:free
 OPENROUTER_SITE_URL=https://schnabel.dev
 
 # Analytics secret to bypass mystery mode (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,6 @@ Required in `.env` (see `.env.example`):
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
 - `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
-- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openrouter/free`
 - `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,6 +1,12 @@
 import type { House } from "@/common/types.ts";
 
-export const DEFAULT_OPENROUTER_MODEL = "openrouter/free";
+const OPENROUTER_MODELS = [
+  "qwen/qwen3-235b-a22b:free",
+  "deepseek/deepseek-chat-v3-0324:free",
+  "meta-llama/llama-4-maverick:free",
+  "mistralai/mistral-small-3.2-24b-instruct:free",
+] as const;
+const DEFAULT_OPENROUTER_MODEL = OPENROUTER_MODELS[0];
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
@@ -54,13 +60,6 @@ export interface GeneratedOpenRouterContent {
 
 export function isOpenRouterConfigured(): boolean {
   return Boolean(process.env["OPENROUTER_API_KEY"]);
-}
-
-export function getOpenRouterModel(): string {
-  const model = process.env["OPENROUTER_MODEL"]?.trim();
-  return model === undefined || model.length === 0
-    ? DEFAULT_OPENROUTER_MODEL
-    : model;
 }
 
 export function buildYearAnnouncementPrompt({
@@ -174,7 +173,7 @@ async function generateOpenRouterContent({
     method: "POST",
     headers,
     body: JSON.stringify({
-      model: getOpenRouterModel(),
+      models: OPENROUTER_MODELS,
       messages,
       temperature,
       max_tokens: maxTokens,
@@ -183,9 +182,7 @@ async function generateOpenRouterContent({
 
   const payload = (await response.json()) as OpenRouterChatResponse;
   if (!response.ok) {
-    const errorMessage =
-      payload.error?.message ??
-      `OpenRouter request failed with status ${response.status}`;
+    const errorMessage = payload.error?.message ?? `OpenRouter request failed with status ${response.status}`;
     throw new OpenRouterError(errorMessage, response.status);
   }
 
@@ -196,7 +193,7 @@ async function generateOpenRouterContent({
 
   return {
     content,
-    model: payload.model?.trim() ? payload.model.trim() : getOpenRouterModel(),
+    model: payload.model?.trim() ? payload.model.trim() : DEFAULT_OPENROUTER_MODEL,
   };
 }
 

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildExplanationPrompt,
   buildYearAnnouncementPrompt,
-  DEFAULT_OPENROUTER_MODEL,
   generateExplanation,
   generateYearAnnouncement,
-  getOpenRouterModel,
   OpenRouterError,
   sanitizeAnnouncementContent,
   sanitizeExplanationContent,
@@ -64,10 +62,35 @@ describe("openRouterService", () => {
     expect(content).toHaveLength(900);
   });
 
-  it("defaults to a free OpenRouter model", () => {
-    vi.stubEnv("OPENROUTER_MODEL", "");
+  it("sends an inline free OpenRouter model fallback list", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "Inline model list answer." } }],
+        }),
+    });
+    vi.stubGlobal("fetch", fetch);
 
-    expect(getOpenRouterModel()).toBe(DEFAULT_OPENROUTER_MODEL);
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).resolves.toEqual({
+      content: "Inline model list answer.",
+      model: "qwen/qwen3-235b-a22b:free",
+    });
+
+    const request = fetch.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(request.body as string) as { models: string[]; model?: string };
+
+    expect(requestBody.model).toBeUndefined();
+    expect(requestBody.models).toEqual([
+      "qwen/qwen3-235b-a22b:free",
+      "deepseek/deepseek-chat-v3-0324:free",
+      "meta-llama/llama-4-maverick:free",
+      "mistralai/mistral-small-3.2-24b-instruct:free",
+    ]);
+    expect(requestBody.models).not.toContain("openrouter/free");
   });
 
   it("returns sanitized year announcement content from OpenRouter", async () => {
@@ -122,9 +145,8 @@ describe("openRouterService", () => {
     });
   });
 
-  it("falls back to the requested model when the response omits a model", async () => {
+  it("falls back to the first inline model label when the response omits a model", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
-    vi.stubEnv("OPENROUTER_MODEL", "custom/requested-model");
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -146,7 +168,7 @@ describe("openRouterService", () => {
       generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
     ).resolves.toEqual({
       content: "Fallback model label.",
-      model: "custom/requested-model",
+      model: "qwen/qwen3-235b-a22b:free",
     });
   });
 


### PR DESCRIPTION
### Motivation

- Prevent routing to unsuitable OpenRouter defaults by shipping a curated inline fallback list of free models instead of relying on a single configurable `OPENROUTER_MODEL` value.

### Description

- Add `OPENROUTER_MODELS` array and set `DEFAULT_OPENROUTER_MODEL` to the first entry (`qwen/qwen3-235b-a22b:free`) and remove `getOpenRouterModel()`.
- Change API requests to include a `models` array in the request body instead of a single `model` field and fall back to `DEFAULT_OPENROUTER_MODEL` when the response omits a model.
- Update `.env.example` and `AGENTS.md` to remove the `OPENROUTER_MODEL` option and clarify the inline free model fallback behavior.
- Update tests in `tests/openRouterService.test.ts` to assert the new `models` payload, inline fallback behavior, and adjusted model-label fallbacks.

### Testing

- Ran unit tests with Vitest, including `tests/openRouterService.test.ts`, with mocked `fetch` and environment variables; all tests passed.
- Verified tests assert the `models` array is sent and that fallback model selection uses the first entry; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff3ec07e48333a34fcf8025fb22f0)