### PR TITLE
Send inline free-model fallback list to OpenRouter and update config/tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,8 @@ COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
 # OpenRouter AI features: year promotion announcements and /explain (optional)
-# Uses a free model by default; override only if you know the model is available to your account.
+# Uses an inline free model fallback list to avoid openrouter/free routing to unsuitable models.
 OPENROUTER_API_KEY=your_openrouter_api_key_here
-OPENROUTER_MODEL=openai/gpt-oss-120b:free
 OPENROUTER_SITE_URL=https://schnabel.dev
 
 # Analytics secret to bypass mystery mode (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,6 @@ Required in `.env` (see `.env.example`):
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
 - `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
-- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openrouter/free`
 - `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,6 +1,33 @@
 import type { House } from "@/common/types.ts";
 
-export const DEFAULT_OPENROUTER_MODEL = "openrouter/free";
+export const OPENROUTER_FREE_MODELS = [
+  // biggest / most capable first
+  "nvidia/nemotron-3-ultra-550b-a55b:free",
+  "qwen/qwen3-coder:free",
+  "nousresearch/hermes-3-llama-3.1-405b:free",
+  "nvidia/nemotron-3-super-120b-a12b:free",
+  "openai/gpt-oss-120b:free",
+
+  // strong general / coding fallbacks
+  "qwen/qwen3-next-80b-a3b-instruct:free",
+  "meta-llama/llama-3.3-70b-instruct:free",
+  "poolside/laguna-m.1:free",
+  "google/gemma-4-31b-it:free",
+  "nvidia/nemotron-3-nano-30b-a3b:free",
+  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+  "cohere/north-mini-code:free",
+  "google/gemma-4-26b-a4b-it:free",
+
+  // medium/small but still usable
+  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+  "openai/gpt-oss-20b:free",
+  "nvidia/nemotron-nano-12b-v2-vl:free",
+  "nvidia/nemotron-nano-9b-v2:free",
+  "poolside/laguna-xs.2:free",
+  "meta-llama/llama-3.2-3b-instruct:free",
+  "liquid/lfm-2.5-1.2b-thinking:free",
+  "liquid/lfm-2.5-1.2b-instruct:free",
+];
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
@@ -54,13 +81,6 @@ export interface GeneratedOpenRouterContent {
 
 export function isOpenRouterConfigured(): boolean {
   return Boolean(process.env["OPENROUTER_API_KEY"]);
-}
-
-export function getOpenRouterModel(): string {
-  const model = process.env["OPENROUTER_MODEL"]?.trim();
-  return model === undefined || model.length === 0
-    ? DEFAULT_OPENROUTER_MODEL
-    : model;
 }
 
 export function buildYearAnnouncementPrompt({
@@ -174,7 +194,7 @@ async function generateOpenRouterContent({
     method: "POST",
     headers,
     body: JSON.stringify({
-      model: getOpenRouterModel(),
+      models: OPENROUTER_FREE_MODELS,
       messages,
       temperature,
       max_tokens: maxTokens,
@@ -183,9 +203,7 @@ async function generateOpenRouterContent({
 
   const payload = (await response.json()) as OpenRouterChatResponse;
   if (!response.ok) {
-    const errorMessage =
-      payload.error?.message ??
-      `OpenRouter request failed with status ${response.status}`;
+    const errorMessage = payload.error?.message ?? `OpenRouter request failed with status ${response.status}`;
     throw new OpenRouterError(errorMessage, response.status);
   }
 
@@ -196,7 +214,7 @@ async function generateOpenRouterContent({
 
   return {
     content,
-    model: payload.model?.trim() ? payload.model.trim() : getOpenRouterModel(),
+    model: payload.model?.trim() ? payload.model.trim() : (OPENROUTER_FREE_MODELS[0] ?? "OpenRouter free model"),
   };
 }
 

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildExplanationPrompt,
   buildYearAnnouncementPrompt,
-  DEFAULT_OPENROUTER_MODEL,
   generateExplanation,
+  OPENROUTER_FREE_MODELS,
   generateYearAnnouncement,
-  getOpenRouterModel,
   OpenRouterError,
   sanitizeAnnouncementContent,
   sanitizeExplanationContent,
@@ -64,10 +63,30 @@ describe("openRouterService", () => {
     expect(content).toHaveLength(900);
   });
 
-  it("defaults to a free OpenRouter model", () => {
-    vi.stubEnv("OPENROUTER_MODEL", "");
+  it("sends the inline free model fallback list to OpenRouter", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "Inline model answer." } }],
+        }),
+    });
+    vi.stubGlobal("fetch", fetch);
 
-    expect(getOpenRouterModel()).toBe(DEFAULT_OPENROUTER_MODEL);
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).resolves.toEqual({
+      content: "Inline model answer.",
+      model: OPENROUTER_FREE_MODELS[0],
+    });
+
+    const request = fetch.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(request.body as string) as { model?: string; models?: string[] };
+
+    expect(requestBody.model).toBeUndefined();
+    expect(requestBody.models).toEqual(OPENROUTER_FREE_MODELS);
+    expect(requestBody.models).not.toContain("openrouter/free");
   });
 
   it("returns sanitized year announcement content from OpenRouter", async () => {
@@ -122,9 +141,8 @@ describe("openRouterService", () => {
     });
   });
 
-  it("falls back to the requested model when the response omits a model", async () => {
+  it("falls back to the first inline model label when the response omits a model", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
-    vi.stubEnv("OPENROUTER_MODEL", "custom/requested-model");
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -146,7 +164,7 @@ describe("openRouterService", () => {
       generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
     ).resolves.toEqual({
       content: "Fallback model label.",
-      model: "custom/requested-model",
+      model: OPENROUTER_FREE_MODELS[0],
     });
   });
 


### PR DESCRIPTION
### Motivation

- Avoid routing to the legacy `openrouter/free` fallback which can select unsuitable models by providing a prioritized inline list of free models for OpenRouter requests.

### Description

- Replace the single default model with an exported `OPENROUTER_FREE_MODELS` array in `src/services/openRouterService.ts` and send that list under `models` in the OpenRouter request payload. 
- Remove `getOpenRouterModel`/`DEFAULT_OPENROUTER_MODEL` and instead fall back to the first entry of `OPENROUTER_FREE_MODELS` when the response omits a `model` label. 
- Update `.env.example` to remove the `OPENROUTER_MODEL` example and change the comment to mention the inline free model fallback list. 
- Update `AGENTS.md` to remove the previous note about a configurable `OPENROUTER_MODEL`, and revise `tests/openRouterService.test.ts` to assert the new `models` request payload and fallback behavior.

### Testing

- Ran unit tests with `vitest` and the updated `tests/openRouterService.test.ts` passed. 
- All automated tests in the suite passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff3ec07e48333a34fcf8025fb22f0)