### PR TITLE
Use inline OpenRouter free-model fallback list and send top three models to API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
 # OpenRouter AI features: year promotion announcements and /explain (optional)
-# Uses an inline free model fallback list (sent three at a time) to avoid openrouter/free routing.
+# Uses three inline free model fallbacks tuned for concise explanations.
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 OPENROUTER_SITE_URL=https://schnabel.dev
 

--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,8 @@ COUNTING_CHANNEL_ID=your_counting_channel_id_here
 GRINGOTTS_CHANNEL_ID=your_gringotts_channel_id_here
 
 # OpenRouter AI features: year promotion announcements and /explain (optional)
-# Uses a free model by default; override only if you know the model is available to your account.
+# Uses an inline free model fallback list (sent three at a time) to avoid openrouter/free routing.
 OPENROUTER_API_KEY=your_openrouter_api_key_here
-OPENROUTER_MODEL=openai/gpt-oss-120b:free
 OPENROUTER_SITE_URL=https://schnabel.dev
 
 # Analytics secret to bypass mystery mode (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,6 @@ Required in `.env` (see `.env.example`):
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
 - `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
-- `OPENROUTER_MODEL` - (optional) OpenRouter model slug for AI features; defaults to `openrouter/free`
 - `OPENROUTER_SITE_URL` - (optional) Referer URL sent to OpenRouter
 
 ### Command Pattern

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,34 +1,13 @@
 import type { House } from "@/common/types.ts";
 
 export const OPENROUTER_FREE_MODELS = [
-  // biggest / most capable first
-  "nvidia/nemotron-3-ultra-550b-a55b:free",
-  "qwen/qwen3-coder:free",
-  "nousresearch/hermes-3-llama-3.1-405b:free",
-  "nvidia/nemotron-3-super-120b-a12b:free",
-  "openai/gpt-oss-120b:free",
-
-  // strong general / coding fallbacks
-  "qwen/qwen3-next-80b-a3b-instruct:free",
+  // Strong general-purpose explainer for concise, helpful answers.
   "meta-llama/llama-3.3-70b-instruct:free",
-  "poolside/laguna-m.1:free",
+  // Balanced instruction-following fallback for educational explanations.
   "google/gemma-4-31b-it:free",
-  "nvidia/nemotron-3-nano-30b-a3b:free",
-  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
-  "cohere/north-mini-code:free",
-  "google/gemma-4-26b-a4b-it:free",
-
-  // medium/small but still usable
-  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-  "openai/gpt-oss-20b:free",
-  "nvidia/nemotron-nano-12b-v2-vl:free",
-  "nvidia/nemotron-nano-9b-v2:free",
-  "poolside/laguna-xs.2:free",
-  "meta-llama/llama-3.2-3b-instruct:free",
-  "liquid/lfm-2.5-1.2b-thinking:free",
+  // Small/simple fallback that should still answer when larger models are busy.
   "liquid/lfm-2.5-1.2b-instruct:free",
 ];
-
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
 const MAX_EXPLANATION_LENGTH = 4000;
@@ -194,7 +173,7 @@ async function generateOpenRouterContent({
     method: "POST",
     headers,
     body: JSON.stringify({
-      models: OPENROUTER_FREE_MODELS.slice(0, 3),
+      models: OPENROUTER_FREE_MODELS,
       messages,
       temperature,
       max_tokens: maxTokens,

--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,6 +1,33 @@
 import type { House } from "@/common/types.ts";
 
-export const DEFAULT_OPENROUTER_MODEL = "openrouter/free";
+export const OPENROUTER_FREE_MODELS = [
+  // biggest / most capable first
+  "nvidia/nemotron-3-ultra-550b-a55b:free",
+  "qwen/qwen3-coder:free",
+  "nousresearch/hermes-3-llama-3.1-405b:free",
+  "nvidia/nemotron-3-super-120b-a12b:free",
+  "openai/gpt-oss-120b:free",
+
+  // strong general / coding fallbacks
+  "qwen/qwen3-next-80b-a3b-instruct:free",
+  "meta-llama/llama-3.3-70b-instruct:free",
+  "poolside/laguna-m.1:free",
+  "google/gemma-4-31b-it:free",
+  "nvidia/nemotron-3-nano-30b-a3b:free",
+  "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+  "cohere/north-mini-code:free",
+  "google/gemma-4-26b-a4b-it:free",
+
+  // medium/small but still usable
+  "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+  "openai/gpt-oss-20b:free",
+  "nvidia/nemotron-nano-12b-v2-vl:free",
+  "nvidia/nemotron-nano-9b-v2:free",
+  "poolside/laguna-xs.2:free",
+  "meta-llama/llama-3.2-3b-instruct:free",
+  "liquid/lfm-2.5-1.2b-thinking:free",
+  "liquid/lfm-2.5-1.2b-instruct:free",
+];
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
 const MAX_ANNOUNCEMENT_LENGTH = 900;
@@ -54,13 +81,6 @@ export interface GeneratedOpenRouterContent {
 
 export function isOpenRouterConfigured(): boolean {
   return Boolean(process.env["OPENROUTER_API_KEY"]);
-}
-
-export function getOpenRouterModel(): string {
-  const model = process.env["OPENROUTER_MODEL"]?.trim();
-  return model === undefined || model.length === 0
-    ? DEFAULT_OPENROUTER_MODEL
-    : model;
 }
 
 export function buildYearAnnouncementPrompt({
@@ -174,7 +194,7 @@ async function generateOpenRouterContent({
     method: "POST",
     headers,
     body: JSON.stringify({
-      model: getOpenRouterModel(),
+      models: OPENROUTER_FREE_MODELS.slice(0, 3),
       messages,
       temperature,
       max_tokens: maxTokens,
@@ -183,9 +203,7 @@ async function generateOpenRouterContent({
 
   const payload = (await response.json()) as OpenRouterChatResponse;
   if (!response.ok) {
-    const errorMessage =
-      payload.error?.message ??
-      `OpenRouter request failed with status ${response.status}`;
+    const errorMessage = payload.error?.message ?? `OpenRouter request failed with status ${response.status}`;
     throw new OpenRouterError(errorMessage, response.status);
   }
 
@@ -196,7 +214,7 @@ async function generateOpenRouterContent({
 
   return {
     content,
-    model: payload.model?.trim() ? payload.model.trim() : getOpenRouterModel(),
+    model: payload.model?.trim() ? payload.model.trim() : (OPENROUTER_FREE_MODELS[0] ?? "OpenRouter free model"),
   };
 }
 

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -63,7 +63,7 @@ describe("openRouterService", () => {
     expect(content).toHaveLength(900);
   });
 
-  it("sends the top three inline free model fallbacks to OpenRouter", async () => {
+  it("sends the three inline explanation model fallbacks to OpenRouter", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
     const fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -85,7 +85,7 @@ describe("openRouterService", () => {
     const requestBody = JSON.parse(request.body as string) as { model?: string; models?: string[] };
 
     expect(requestBody.model).toBeUndefined();
-    expect(requestBody.models).toEqual(OPENROUTER_FREE_MODELS.slice(0, 3));
+    expect(requestBody.models).toEqual(OPENROUTER_FREE_MODELS);
     expect(requestBody.models).toHaveLength(3);
     expect(requestBody.models).not.toContain("openrouter/free");
   });

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildExplanationPrompt,
   buildYearAnnouncementPrompt,
-  DEFAULT_OPENROUTER_MODEL,
   generateExplanation,
+  OPENROUTER_FREE_MODELS,
   generateYearAnnouncement,
-  getOpenRouterModel,
   OpenRouterError,
   sanitizeAnnouncementContent,
   sanitizeExplanationContent,
@@ -64,10 +63,31 @@ describe("openRouterService", () => {
     expect(content).toHaveLength(900);
   });
 
-  it("defaults to a free OpenRouter model", () => {
-    vi.stubEnv("OPENROUTER_MODEL", "");
+  it("sends the top three inline free model fallbacks to OpenRouter", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "Inline model answer." } }],
+        }),
+    });
+    vi.stubGlobal("fetch", fetch);
 
-    expect(getOpenRouterModel()).toBe(DEFAULT_OPENROUTER_MODEL);
+    await expect(
+      generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
+    ).resolves.toEqual({
+      content: "Inline model answer.",
+      model: OPENROUTER_FREE_MODELS[0],
+    });
+
+    const request = fetch.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(request.body as string) as { model?: string; models?: string[] };
+
+    expect(requestBody.model).toBeUndefined();
+    expect(requestBody.models).toEqual(OPENROUTER_FREE_MODELS.slice(0, 3));
+    expect(requestBody.models).toHaveLength(3);
+    expect(requestBody.models).not.toContain("openrouter/free");
   });
 
   it("returns sanitized year announcement content from OpenRouter", async () => {
@@ -122,9 +142,8 @@ describe("openRouterService", () => {
     });
   });
 
-  it("falls back to the requested model when the response omits a model", async () => {
+  it("falls back to the first inline model label when the response omits a model", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
-    vi.stubEnv("OPENROUTER_MODEL", "custom/requested-model");
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
@@ -146,7 +165,7 @@ describe("openRouterService", () => {
       generateExplanation({ question: "What is spaced repetition?", username: "Luna" }),
     ).resolves.toEqual({
       content: "Fallback model label.",
-      model: "custom/requested-model",
+      model: OPENROUTER_FREE_MODELS[0],
     });
   });
 


### PR DESCRIPTION
### Motivation

- Reduce reliance on the legacy `openrouter/free` routing and make AI requests more robust by trying multiple free models inline. 
- Simplify configuration by removing the optional `OPENROUTER_MODEL` environment variable and using an internal fallback list.

### Description

- Add `OPENROUTER_FREE_MODELS` array in `src/services/openRouterService.ts` and remove the `getOpenRouterModel`/`DEFAULT_OPENROUTER_MODEL` usage. 
- Send the top three free-model fallbacks in the API payload using `models: OPENROUTER_FREE_MODELS.slice(0, 3)` instead of a single `model` field, and fallback to `OPENROUTER_FREE_MODELS[0]` when the response omits a model. 
- Update `tests/openRouterService.test.ts` to assert the inline `models` payload and the new fallback behavior and to remove references to the old model env var. 
- Update `AGENTS.md` and `.env.example` to remove `OPENROUTER_MODEL` and document the inline free-model fallback behavior. 

### Testing

- Ran the `openRouterService` unit tests in `tests/openRouterService.test.ts` under Vitest and they passed. 
- Verified the new test asserting the `models` array is sent to OpenRouter and the fallback model label behavior passed. 
- Ran the full test suite with `vitest` and observed no failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ff3ec07e48333a34fcf8025fb22f0)