### PR TITLE
Prevent OpenRouter reasoning leakage in year announcements

### DIFF
--- a/src/services/openRouterService.ts
+++ b/src/services/openRouterService.ts
@@ -1,11 +1,19 @@
 import type { House } from "@/common/types.ts";
 
 export const OPENROUTER_MODELS = [
-  // Default: strongest free model for concise explanations and announcements.
+  // Default: strongest free model for concise explanations.
   "nvidia/nemotron-3-ultra-550b-a55b:free",
   // Strong free Google fallback.
   "google/gemma-4-31b-it:free",
   // Capable free open-weight fallback from a different provider.
+  "openai/gpt-oss-120b:free",
+];
+
+export const OPENROUTER_YEAR_ANNOUNCEMENT_MODELS = [
+  // Prefer a non-reasoning model for short public announcements so the response budget is not spent on thinking.
+  "google/gemma-4-31b-it:free",
+  // Keep the site-wide default available as a fallback, but explicitly disable/exclude reasoning for this call.
+  "nvidia/nemotron-3-ultra-550b-a55b:free",
   "openai/gpt-oss-120b:free",
 ];
 
@@ -46,6 +54,7 @@ export interface OpenRouterChatResponse {
   choices?: {
     message?: {
       content?: string | null;
+      reasoning?: string | null;
     };
   }[];
   error?: {
@@ -149,12 +158,19 @@ function truncateContent(content: string, maxLength: number): string {
 async function generateOpenRouterContent({
   messages,
   maxTokens,
+  models = OPENROUTER_MODELS,
+  reasoning,
   temperature,
   emptyResponseMessage,
   sanitizer,
 }: {
   messages: OpenRouterMessage[];
   maxTokens: number;
+  models?: string[];
+  reasoning?: {
+    effort?: "max" | "xhigh" | "high" | "medium" | "low" | "minimal" | "none";
+    exclude?: boolean;
+  };
   temperature: number;
   emptyResponseMessage: string;
   sanitizer: (content: string) => string;
@@ -175,10 +191,11 @@ async function generateOpenRouterContent({
     method: "POST",
     headers,
     body: JSON.stringify({
-      models: OPENROUTER_MODELS,
+      models,
       messages,
       temperature,
       max_tokens: maxTokens,
+      ...(reasoning ? { reasoning } : {}),
     }),
   });
 
@@ -195,7 +212,7 @@ async function generateOpenRouterContent({
 
   return {
     content,
-    model: payload.model?.trim() ? payload.model.trim() : (OPENROUTER_MODELS[0] ?? "OpenRouter model"),
+    model: payload.model?.trim() ? payload.model.trim() : (models[0] ?? "OpenRouter model"),
   };
 }
 
@@ -212,7 +229,9 @@ export async function generateYearAnnouncement(
       { role: "user", content: buildYearAnnouncementPrompt(request) },
     ],
     temperature: 0.8,
-    maxTokens: 140,
+    maxTokens: 260,
+    models: OPENROUTER_YEAR_ANNOUNCEMENT_MODELS,
+    reasoning: { effort: "none", exclude: true },
     emptyResponseMessage: "OpenRouter returned an empty year announcement.",
     sanitizer: sanitizeAnnouncementContent,
   });

--- a/tests/openRouterService.test.ts
+++ b/tests/openRouterService.test.ts
@@ -4,6 +4,7 @@ import {
   buildYearAnnouncementPrompt,
   generateExplanation,
   OPENROUTER_MODELS,
+  OPENROUTER_YEAR_ANNOUNCEMENT_MODELS,
   generateYearAnnouncement,
   OpenRouterError,
   sanitizeAnnouncementContent,
@@ -92,28 +93,39 @@ describe("openRouterService", () => {
     expect(requestBody.models).not.toContain("openrouter/free");
   });
 
-  it("returns sanitized year announcement content from OpenRouter", async () => {
+  it("sends non-reasoning year announcement fallbacks to OpenRouter", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            choices: [
-              {
-                message: {
-                  content: "  Well done, Ravenclaw!\nYou earned it. ",
-                },
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [
+            {
+              message: {
+                content: "  Well done, Ravenclaw!\nYou earned it. ",
               },
-            ],
-          }),
-      }),
-    );
+            },
+          ],
+        }),
+    });
+    vi.stubGlobal("fetch", fetch);
 
     await expect(generateYearAnnouncement(request)).resolves.toBe(
       "Well done, Ravenclaw! You earned it.",
     );
+
+    const openRouterRequest = fetch.mock.calls[0]?.[1] as RequestInit;
+    const requestBody = JSON.parse(openRouterRequest.body as string) as {
+      max_tokens?: number;
+      models?: string[];
+      reasoning?: { effort?: string; exclude?: boolean };
+    };
+
+    expect(requestBody.models).toEqual(OPENROUTER_YEAR_ANNOUNCEMENT_MODELS);
+    expect(requestBody.models?.[0]).toBe("google/gemma-4-31b-it:free");
+    expect(requestBody.models).toContain("nvidia/nemotron-3-ultra-550b-a55b:free");
+    expect(requestBody.max_tokens).toBe(260);
+    expect(requestBody.reasoning).toEqual({ effort: "none", exclude: true });
   });
 
   it("returns sanitized explanation content from OpenRouter", async () => {


### PR DESCRIPTION
### Motivation
- Year announcement generation could use a reasoning-focused default model and exhaust its short token budget on internal reasoning, which risked leaking parts of the prompt into public announcements.

### Description
- Add `OPENROUTER_YEAR_ANNOUNCEMENT_MODELS` that prefers `google/gemma-4-31b-it:free` and keeps other models as fallbacks for announcements.
- Extend `generateOpenRouterContent` to accept per-request `models` and a `reasoning` option and include `reasoning` in the outgoing request when provided.
- Update `generateYearAnnouncement` to use the announcement-specific model list, disable reasoning with `reasoning: { effort: "none", exclude: true }`, and increase `maxTokens` from `140` to `260` so short announcements are not starved by thinking tokens.
- Update `tests/openRouterService.test.ts` to assert the announcement request includes the dedicated `models`, `max_tokens`, and `reasoning` controls and add `OPENROUTER_YEAR_ANNOUNCEMENT_MODELS` to test imports.

### Testing
- Ran `pnpm test tests/openRouterService.test.ts --run` and the test file passed (all tests green).
- Ran `pnpm typecheck` and TypeScript checks succeeded.
- Ran `pnpm lint` and linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a430864fb7883339fd03793c96c3bcc)