### PR TITLE
Disable OpenRouter year announcements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ Required in `.env` (see `.env.example`):
 - `EXCLUDE_VOICE_CHANNEL_IDS` - Voice channels to exclude from tracking
 - `SUBMISSION_CHANNEL_IDS` - Channels for submissions
 - `MYSTERY_SECRET` - (optional) Secret to bypass mystery mode in analytics
-- `OPENROUTER_API_KEY` - (optional) Enables AI-generated year promotion announcements and `/explain` responses through OpenRouter
+- `OPENROUTER_API_KEY` - (optional) Enables `/explain` responses through OpenRouter; year promotion announcements currently always use static fallback messages
 
 ### Command Pattern
 

--- a/src/discord/events/voiceStateUpdate/yearRole.ts
+++ b/src/discord/events/voiceStateUpdate/yearRole.ts
@@ -12,9 +12,6 @@ import {
 import { getYearFromMonthlyVoiceTime } from "@/discord/core/year.ts";
 import { eq, isNotNull } from "drizzle-orm";
 import { updateMember } from "@/discord/utils/updateMember.ts";
-import {
-  generateYearAnnouncement,
-} from "@/services/openRouterService.ts";
 
 const log = createLogger("YearRole");
 
@@ -54,13 +51,10 @@ export async function announceYearPromotion(
       embeds: [
         {
           title: "New Activity Rank Attained!",
-          description: await getYearAnnouncementDescription({
+          description: getYearAnnouncementDescription({
             house: user.house,
             roleId,
             hours,
-            member,
-            year,
-            ctx,
           }),
           color: HOUSE_COLORS[user.house],
         },
@@ -76,54 +70,19 @@ export async function announceYearPromotion(
   }
 }
 
-async function getYearAnnouncementDescription({
+function getYearAnnouncementDescription({
   house,
   roleId,
   hours,
-  member,
-  year,
-  ctx,
 }: {
   house: House;
   roleId: string;
   hours: number;
-  member: GuildMember;
-  year: number;
-  ctx: { userId: string; username: string };
-}): Promise<string> {
+}): string {
   const role = roleMention(roleId);
   const hourText = hours.toString() + (hours === 1 ? " hour" : " hours");
 
-  if (!process.env.OPENROUTER_API_KEY) {
-    return formatFallbackYearMessage(house, role, hourText);
-  }
-
-  try {
-    const result = await generateYearAnnouncement({
-      house,
-      roleMention: role,
-      hours: hourText,
-      year,
-      username: member.displayName,
-    });
-    if (!result?.content.trim()) {
-      log.warn(
-        "OpenRouter returned an empty year promotion announcement",
-        { ...ctx, result },
-      );
-      return formatFallbackYearMessage(house, role, hourText);
-    }
-    return result.content;
-  } catch (error) {
-    log.error(
-      "Falling back to static year promotion announcement after OpenRouter failure",
-      {
-        ...ctx,
-        error: error instanceof Error ? error.message : String(error),
-      },
-    );
-    return formatFallbackYearMessage(house, role, hourText);
-  }
+  return formatFallbackYearMessage(house, role, hourText);
 }
 
 function formatFallbackYearMessage(


### PR DESCRIPTION
### Motivation
- Prevent runtime/OpenRouter dependency for year promotion copy and use stable, static messages for announcements.

### Description
- Removed `generateYearAnnouncement` usage from `src/discord/events/voiceStateUpdate/yearRole.ts` and made announcements always use the local fallback message formatter.
- Simplified `getYearAnnouncementDescription` to a synchronous helper that returns `formatFallbackYearMessage` directly and removed the `OpenRouter` import and related async/error handling.
- Updated `AGENTS.md` to clarify that `OPENROUTER_API_KEY` now only enables `/explain` while year promotion announcements use static fallback messages.

### Testing
- Ran lint with `pnpm lint` and TypeScript checks with `pnpm typecheck`, both completed successfully.
- Ran unit tests with `pnpm test -- --run`, and Vitest reported `116 passed | 1 skipped` (12 test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44f31c7c708333a550b89cfedade42)